### PR TITLE
TrueNAS Admin-Tool v0.2

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,0 +1,24 @@
+; https://editorconfig.org/
+; https://github.com/editorconfig/editorconfig-core-go/blob/master/.editorconfig
+
+root = true
+
+[*]
+insert_final_newline = true
+charset = utf-8
+trim_trailing_whitespace = true
+indent_style = space
+indent_size = 2
+
+[{Makefile,go.mod,go.sum,*.go,.gitmodules}]
+indent_style = tab
+indent_size = 4
+
+[*.md]
+indent_size = 4
+trim_trailing_whitespace = false
+
+eclint_indent_style = unset
+
+[Dockerfile]
+indent_size = 4

--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,4 @@
+truenas-admin
+admin-tool
+key.txt
+datasets.tsv

--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -1,0 +1,163 @@
+{
+    // Use IntelliSense to learn about possible attributes.
+    // Hover to view descriptions of existing attributes.
+    // For more information, visit: https://go.microsoft.com/fwlink/?linkid=830387
+    "version": "0.2.0",
+    "configurations": [
+
+        {
+            "name": "dataset list",
+            "type": "go",
+            "request": "launch",
+            "mode": "debug",
+            "program": "${workspaceFolder}",
+            "args": ["--debug","--key-file=${workspaceFolder}/key.txt","dataset","list"]
+        },
+        {
+          "name": "ds ls -r",
+          "type": "go",
+          "request": "launch",
+          "mode": "debug",
+          "program": "${workspaceFolder}",
+          "args": ["--debug","--key-file=${workspaceFolder}/key.txt","dataset","list","--recursive"]
+        },
+        {
+            "name": "dataset list dozer",
+            "type": "go",
+            "request": "launch",
+            "mode": "debug",
+            "program": "${workspaceFolder}",
+            "args": ["--debug","--key-file=${workspaceFolder}/key.txt","dataset","list","dozer"]
+        },
+        {
+          "name": "dataset ls -r dozer",
+          "type": "go",
+          "request": "launch",
+          "mode": "debug",
+          "program": "${workspaceFolder}",
+          "args": ["--debug","--key-file=${workspaceFolder}/key.txt","dataset","ls","-r","dozer"]
+        },
+        {
+          "name": "dataset create dozer/created",
+          "type": "go",
+          "request": "launch",
+          "mode": "debug",
+          "program": "${workspaceFolder}",
+          "args": ["--debug","--key-file=${workspaceFolder}/key.txt","dataset","create","dozer/created"]
+        },
+        {
+          "name": "dataset create --exec=off dozer/created",
+          "type": "go",
+          "request": "launch",
+          "mode": "debug",
+          "program": "${workspaceFolder}",
+          "args": ["--debug","--key-file=${workspaceFolder}/key.txt","dataset","create","--exec=off","dozer/created"]
+        },
+        {
+          "name": "dataset create -o exec=off dozer/created",
+          "type": "go",
+          "request": "launch",
+          "mode": "debug",
+          "program": "${workspaceFolder}",
+          "args": ["--debug","--key-file=${workspaceFolder}/key.txt","dataset","create","-o","exec=off","dozer/created"]
+        },
+        {
+          "name": "dataset create -p dozer/created/parent/child",
+          "type": "go",
+          "request": "launch",
+          "mode": "debug",
+          "program": "${workspaceFolder}",
+          "args": ["--debug","--key-file=${workspaceFolder}/key.txt","dataset","create","--create_parents","dozer/created/parent/child"]  // -p also works.
+        },
+        {
+          "name": "dataset update --exec=off dozer/created",
+          "type": "go",
+          "request": "launch",
+          "mode": "debug",
+          "program": "${workspaceFolder}",
+          "args": ["--debug","--key-file=${workspaceFolder}/key.txt","dataset","update","--exec=off","dozer/created"]
+        },
+        {
+          "name": "dataset update -o exec=off dozer/created",
+          "type": "go",
+          "request": "launch",
+          "mode": "debug",
+          "program": "${workspaceFolder}",
+          "args": ["--debug","--key-file=${workspaceFolder}/key.txt","dataset","update","-o","exec=off","dozer/created"]
+        },
+        {
+          "name": "dataset rm dozer/created",
+          "type": "go",
+          "request": "launch",
+          "mode": "debug",
+          "program": "${workspaceFolder}",
+          "args": ["--debug","--key-file=${workspaceFolder}/key.txt","dataset","delete","dozer/created"]
+        },
+        {
+          "name": "dataset rm -r dozer/created",
+          "type": "go",
+          "request": "launch",
+          "mode": "debug",
+          "program": "${workspaceFolder}",
+          "args": ["--debug","--key-file=${workspaceFolder}/key.txt","dataset","delete","-r","dozer/created"]
+        },
+         {
+          "name": "dataset share nfs create dozer/created",
+          "type": "go",
+          "request": "launch",
+          "mode": "debug",
+          "program": "${workspaceFolder}",
+          "args": ["--debug","--key-file=${workspaceFolder}/key.txt","share","nfs","create","--comment","made with truenas-admin","--maproot-user=root", "--maproot-group","root","dozer/created"]
+        },
+        {
+          "name": "dataset share nfs update --create dozer/created",
+          "type": "go",
+          "request": "launch",
+          "mode": "debug",
+          "program": "${workspaceFolder}",
+          "args": ["--debug","--key-file=${workspaceFolder}/key.txt","share","nfs","update","--create",/*"--comment","made with truenas-admin","--maproot-user=root", "--maproot-group","root",*/"dozer/created"]
+        },
+        {
+          "name": "dataset share nfs list dozer/created",
+          "type": "go",
+          "request": "launch",
+          "mode": "debug",
+          "program": "${workspaceFolder}",
+          "args": ["--debug","--key-file=${workspaceFolder}/key.txt","share","nfs","list","--name","dozer/created"]
+        },
+        {
+          "name": "dataset mv dozer/created/parent/child dozer/created/child",
+          "type": "go",
+          "request": "launch",
+          "mode": "debug",
+          "program": "${workspaceFolder}",
+          "args": ["--debug","--key-file=${workspaceFolder}/key.txt","dataset","rename","dozer/created/parent/child","dozer/created/child"]
+        },
+        {
+          "name": "snapshot create -r dozer/created@snap",
+          "type": "go",
+          "request": "launch",
+          "mode": "debug",
+          "program": "${workspaceFolder}",
+          "args": ["--debug","--key-file=${workspaceFolder}/key.txt","snapshot","create","dozer/created@snap"]
+        },
+        {
+          // snapshot listing needs to be more flexible, ie like `zfs list -t snapshot -r dozer/created`
+          "name": "snapshot ls -r dozer/created@snap",
+          "type": "go",
+          "request": "launch",
+          "mode": "debug",
+          "program": "${workspaceFolder}",
+          "args": ["--debug","--key-file=${workspaceFolder}/key.txt","snapshot","ls","-r","dozer/created@snap"]
+        },
+        {
+          // snapshot listing needs to be more flexible, ie like `zfs list -t snapshot -r dozer/created`
+          "name": "snapshot rm -r dozer/created@snap",
+          "type": "go",
+          "request": "launch",
+          "mode": "debug",
+          "program": "${workspaceFolder}",
+          "args": ["--debug","--key-file=${workspaceFolder}/key.txt","snapshot","delete","-r","dozer/created@snap"]
+        },
+    ]
+}

--- a/README.md
+++ b/README.md
@@ -1,0 +1,95 @@
+# truenas-admin
+
+`truenas-admin` is a tool for administering datasets, snapshots and network shares that are hosted on a TrueNAS server.
+
+## Install
+
+`go build`
+
+`go install`
+
+## Configuration
+
+TrueNAS hosts can be specified with a JSON configuration file.
+
+```json
+{
+  "hosts":{
+    "fangtooth":{
+      "url":"wss://<servername>/api/current",
+      "api_key":"api key goes here"
+    },
+    "other":{
+      "url":"wss://<servername>/api/current",
+      "api_key":"other api key",
+    }
+  }
+}
+```
+
+The default path is `~/.truenas-admin/config.json`. It can be overridden with --config.
+
+## Run
+
+`truenas-admin --url <websocket server> --api-key <api key> <command>`
+
+### Commands
+
+- list
+	- Print various datasets, snapshots and network shares
+- dataset
+	- Administer datasets/zvols and their associated shares
+- snapshot
+	- Administer snapshots
+- share
+	- Administer network shares
+
+## Testing
+
+`go test -v ./cmd`
+
+## Middleware Patches
+
+The following patches to middlewared are currently needed to support the Incus TrueNAS driver. After making the patches you will need to restart the middlewared service
+
+Modify `zfs.dataset.rename` to support snapshots. The snapshot rename capability is required by Incus.
+
+```diff
+diff --git a/src/middlewared/middlewared/plugins/zfs_/dataset_actions.py b/src/middlewared/middlewared/plugins/zfs_/dataset_actions.py
+index 5dc1780fd8..76c57b554c 100644
+--- a/src/middlewared/middlewared/plugins/zfs_/dataset_actions.py
++++ b/src/middlewared/middlewared/plugins/zfs_/dataset_actions.py
+@@ -83,10 +83,11 @@ class ZFSDatasetService(Service):
+             Bool('recursive', default=False)
+         )
+     )
++
+     def rename(self, name, options):
+         try:
+             with libzfs.ZFS() as zfs:
+-                dataset = zfs.get_dataset(name)
++                dataset = zfs.get_object(name)
+                 dataset.rename(options['new_name'], recursive=options['recursive'])
+         except libzfs.ZFSException as e:
+             self.logger.error('Failed to rename dataset', exc_info=True)
+```
+
+Increase `max_calls` to 100. Incus will exceed 20 calls in 60 seconds when creating a storage volume. This will be resolved with a connection-cache in future
+
+```diff
+diff --git a/src/middlewared/middlewared/utils/rate_limit/cache.py b/src/middlewared/middlewared/utils/rate_limit/cache.py
+index b04ecc1ec1..40797b71a7 100644
+--- a/src/middlewared/middlewared/utils/rate_limit/cache.py
++++ b/src/middlewared/middlewared/utils/rate_limit/cache.py
+@@ -12,7 +12,7 @@ __all__ = ['RateLimitCache']
+ @dataclass(frozen=True)
+ class RateLimitConfig:
+     """The maximum number of calls per unique consumer of the endpoint."""
+-    max_calls: int = 20
++    max_calls: int = 100
+     """The maximum time in seconds that a unique consumer may request an
+     endpoint that is being rate limited."""
+     max_period: int = 60
+
+```
+

--- a/cmd/dataset.go
+++ b/cmd/dataset.go
@@ -1,0 +1,487 @@
+package cmd
+
+import (
+	//"encoding/json"
+	"errors"
+	"fmt"
+	"strconv"
+	"strings"
+	"truenas/truenas-admin/core"
+
+	"github.com/spf13/cobra"
+)
+
+var datasetCmd = &cobra.Command{
+	Use:   "dataset",
+	Short: "Edit or list datasets/zvols and their shares on a remote or local machine",
+	Run: func(cmd *cobra.Command, args []string) {
+		if len(args) == 0 {
+			cmd.HelpFunc()(cmd, args)
+			return
+		}
+	},
+}
+
+/*
+	TODO: most of these commands should be modified to support specifying multiple datasets,
+	thus allowing a cheap "batch" mode.
+
+	Ie, even when the underlying API doesn't support multiple datasets, we would instead use
+	core.bulk, or worst case, iteration
+*/
+
+var datasetCreateCmd = &cobra.Command{
+	Use:   "create [flags] <dataset>",
+	Short: "Creates a dataset/zvol.",
+	Args:  cobra.MinimumNArgs(1),
+}
+
+var datasetUpdateCmd = &cobra.Command{
+	Use:     "update [flags] <dataset>",
+	Short:   "Updates an existing dataset/zvol.",
+	Args:    cobra.MinimumNArgs(1),
+	Aliases: []string{"set"},
+}
+
+var datasetDeleteCmd = &cobra.Command{
+	Use:     "delete [flags] <dataset>",
+	Short:   "Deletes a dataset/zvol.",
+	Args:    cobra.MinimumNArgs(1),
+	Aliases: []string{"rm"},
+}
+
+var datasetListCmd = &cobra.Command{
+	Use:     "list [flags] [dataset]...",
+	Short:   "Prints a table of all datasets/zvols, given a source and an optional set of properties.",
+	Aliases: []string{"ls"},
+}
+
+var datasetPromoteCmd = &cobra.Command{
+	Use:   "promote [flags] <dataset>",
+	Short: "Promote a clone dataset to no longer depend on the origin snapshot.",
+	Args:  cobra.ExactArgs(1),
+}
+
+var datasetRenameCmd = &cobra.Command{
+	Use:   "rename [flags] <old dataset>[@<old snapshot>] <new dataset|new snapshot>",
+	Short: "Rename a ZFS dataset",
+	Long: `Renames the given dataset. The new target can be located anywhere in the ZFS hierarchy, with the exception of snapshots.
+Snapshots can only be re‐named within the parent file system or volume.
+When renaming a snapshot, the parent file system of the snapshot does not need to be specified as part of the second argument.
+Renamed file systems can inherit new mount points, in which case they are unmounted and remounted at the new mount point.`,
+	Args:    cobra.ExactArgs(2),
+	Aliases: []string{"mv"},
+}
+
+var g_compressionEnum = [...]string{
+	"on", "off", "gzip",
+	"gzip-1", "gzip-9",
+	"lz4", "lzjb", "zle", "zstd",
+	"zstd-1", "zstd-2", "zstd-3", "zstd-4", "zstd-5", "zstd-6", "zstd-7", "zstd-8", "zstd-9", "zstd-10",
+	"zstd-11", "zstd-12", "zstd-13", "zstd-14", "zstd-15", "zstd-16", "zstd-17", "zstd-18", "zstd-19",
+	"zstd-fast",
+	"zstd-fast-1", "zstd-fast-2", "zstd-fast-3", "zstd-fast-4", "zstd-fast-5", "zstd-fast-6", "zstd-fast-7", "zstd-fast-8", "zstd-fast-9",
+	"zstd-fast-10", "zstd-fast-20", "zstd-fast-30", "zstd-fast-40", "zstd-fast-50", "zstd-fast-60", "zstd-fast-70", "zstd-fast-80", "zstd-fast-90",
+	"zstd-fast-100", "zstd-fast-500", "zstd-fast-1000",
+}
+
+var g_datasetCreateUpdateEnums map[string][]string
+var g_datasetListEnums map[string][]string
+
+func init() {
+	datasetCreateCmd.RunE = func(cmd *cobra.Command, args []string) error {
+		return createOrUpdateDataset(cmd, ValidateAndLogin(), args)
+	}
+
+	datasetUpdateCmd.RunE = func(cmd *cobra.Command, args []string) error {
+		return createOrUpdateDataset(cmd, ValidateAndLogin(), args)
+	}
+
+	datasetDeleteCmd.RunE = func(cmd *cobra.Command, args []string) error {
+		return deleteDataset(cmd, ValidateAndLogin(), args)
+	}
+
+	datasetListCmd.RunE = func(cmd *cobra.Command, args []string) error {
+		return listDataset(cmd, ValidateAndLogin(), args)
+	}
+
+	datasetPromoteCmd.RunE = func(cmd *cobra.Command, args []string) error {
+		return promoteDataset(cmd, ValidateAndLogin(), args)
+	}
+
+	datasetRenameCmd.RunE = func(cmd *cobra.Command, args []string) error {
+		return renameDataset(cmd, ValidateAndLogin(), args)
+	}
+
+	createUpdateCmds := []*cobra.Command{datasetCreateCmd, datasetUpdateCmd}
+	for _, cmd := range createUpdateCmds {
+		cmd.Flags().String("comments", "", "User defined comments")
+		cmd.Flags().String("managedby", "truenas-admin", "Manager of this dataset, must not be empty")
+		cmd.Flags().String("recordsize", "", "")
+		cmd.Flags().String("sync", "standard", "Controls the behavior of synchronous requests "+
+			AddFlagsEnum(&g_datasetCreateUpdateEnums, "sync", []string{"standard", "always", "disabled"}))
+		cmd.Flags().String("snapdir", "hidden", "Controls whether the .zfs directory is disabled, hidden or visible "+
+			AddFlagsEnum(&g_datasetCreateUpdateEnums, "snapdir", []string{"disabled", "hidden", "visible"}))
+		cmd.Flags().String("compression", "off", "Controls the compression algorithm used for this dataset\n"+
+			AddFlagsEnum(&g_datasetCreateUpdateEnums, "compression", g_compressionEnum[:]))
+		cmd.Flags().String("atime", "inherit", "Controls whether the access time for files is updated when they are read "+
+			AddFlagsEnum(&g_datasetCreateUpdateEnums, "atime", []string{"inherit", "on", "off"}))
+		//cmd.Flags().String("relatime", "inherit", "Controls whether the access time for files is updated periodically "+
+			//AddFlagsEnum(&g_datasetCreateUpdateEnums, "relatime", []string{"inherit", "on", "off"}))
+		cmd.Flags().String("exec", "inherit", "Controls whether processes can be executed from within this file system "+
+			AddFlagsEnum(&g_datasetCreateUpdateEnums, "exec", []string{"inherit", "on", "off"}))
+		cmd.Flags().String("acltype", "inherit", "Controls whether ACLs are enabled and if so what type of ACL to use "+
+			AddFlagsEnum(&g_datasetCreateUpdateEnums, "acltype", []string{"inherit", "posix", "nfsv4", "off"}))
+		cmd.Flags().String("aclmode", "inherit", "Controls how an ACL is modified during chmod(2) and how inherited ACEs are modified by the file creation mode "+
+			AddFlagsEnum(&g_datasetCreateUpdateEnums, "aclmode", []string{"inherit", "passthrough", "restricted", "discard"}))
+		cmd.Flags().String("deduplication", "inherit", ""+
+			AddFlagsEnum(&g_datasetCreateUpdateEnums, "deduplication", []string{"inherit", "on", "verify", "off"}))
+		cmd.Flags().String("checksum", "inherit", ""+
+			AddFlagsEnum(&g_datasetCreateUpdateEnums, "checksum", []string{"inherit", "on", "off", "fletcher2", "fletcher4", "sha256", "sha512", "skein", "edonr", "blake3"}))
+		cmd.Flags().String("readonly", "inherit", ""+
+			AddFlagsEnum(&g_datasetCreateUpdateEnums, "readonly", []string{"inherit", "on", "off"}))
+		cmd.Flags().String("casesensitivity", "inherit", ""+
+			AddFlagsEnum(&g_datasetCreateUpdateEnums, "casesensitivity", []string{"inherit", "sensitive", "insensitive"}))
+		cmd.Flags().String("share-type", "inherit", ""+
+			AddFlagsEnum(&g_datasetCreateUpdateEnums, "share_type", []string{"inherit", "generic", "multiprotocol", "nfs", "smb", "apps"}))
+		//cmd.Flags().String("xattr", "inherit", "Controls whether extended attributes are enabled for this file system "+
+		//	AddFlagsEnum(&g_datasetCreateUpdateEnums, "xattr", []string{"inherit", "on", "off", "dir"})) // 'sa' should be "on"
+		//cmd.Flags().String("encryption-options", "", "")
+		//cmd.Flags().Bool("encryption", false, "")
+		//cmd.Flags().Bool("inherit-encryption", true, "")
+		cmd.Flags().Int64("quota", 0, "")
+		cmd.Flags().Int("quota-warning", 0, "Percentage (1-100 or 0)")
+		cmd.Flags().Int("quota-critical", 0, "Percentage (1-100 or 0)")
+		cmd.Flags().Int64("refquota", 0, "")
+		cmd.Flags().Int("refquota-warning", 0, "Percentage (1-100 or 0)")
+		cmd.Flags().Int("refquota-critical", 0, "Percentage (1-100 or 0)")
+		cmd.Flags().Int64("reservation", 0, "")
+		cmd.Flags().Int64("refreservation", 0, "")
+		cmd.Flags().Int64("special-small-block-size", 0, "")
+		cmd.Flags().Int("copies", 0, "")
+		cmd.Flags().BoolP("create-parents", "p", false, "Creates all the non-existing parent datasets")
+		cmd.Flags().String("user-props", "", "Sets the specified properties")
+		cmd.Flags().StringP("option", "o", "", "Specify property=value,...")
+		cmd.Flags().Int64P("volume", "V", 0, "Creates a volume of the given size instead of a filesystem, should be a multiple of the block size.")
+		cmd.Flags().StringP("volblocksize", "b", "512", "Volume block size "+
+			AddFlagsEnum(&g_datasetCreateUpdateEnums, "volblocksize", []string{"512", "1K", "2K", "4K", "8K", "16K", "32K", "64K", "128K"}))
+		cmd.Flags().BoolP("sparse", "s", false, "Creates a sparse volume with no reservation")
+		cmd.Flags().Bool("force-size", false, "")
+		cmd.Flags().String("snapdev", "hidden", "Controls whether the volume snapshot devices are hidden or visible "+
+			AddFlagsEnum(&g_datasetCreateUpdateEnums, "snapdev", []string{"hidden", "visible"}))
+	}
+
+	g_datasetCreateUpdateEnums["type"] = []string{"volume", "filesystem"}
+
+	datasetDeleteCmd.Flags().BoolP("recursive", "r", false, "Also delete/destroy all children datasets. When the root dataset is specified,\n"+
+		"it will destroy all the children of the root dataset present leaving root dataset intact")
+	datasetDeleteCmd.Flags().BoolP("force", "f", false, "Force delete busy datasets")
+
+	datasetListCmd.Flags().BoolP("recursive", "r", false, "Retrieves properties for children")
+	datasetListCmd.Flags().BoolP("user-properties", "u", false, "Include user-properties")
+	datasetListCmd.Flags().BoolP("json", "j", false, "Equivalent to --format=json")
+	datasetListCmd.Flags().BoolP("no-headers", "H", false, "Equivalent to --format=compact. More easily parsed by scripts")
+	datasetListCmd.Flags().String("format", "table", "Output table format "+
+		AddFlagsEnum(&g_datasetListEnums, "format", []string{"csv", "json", "table", "compact"}))
+	datasetListCmd.Flags().StringP("output", "o", "", "Output property list")
+	datasetListCmd.Flags().BoolP("parseable", "p", false, "Show raw values instead of the already parsed values")
+	datasetListCmd.Flags().BoolP("all", "a", false, "Output all properties")
+	datasetListCmd.Flags().StringP("source", "s", "default", "A comma-separated list of sources to display.\n"+
+		"Those properties coming from a source other than those in this list are ignored.\n"+
+		"Each source must be one of the following: local, default, inherited, temporary, received, or none.\n"+
+		"The default value is all sources.")
+
+	datasetRenameCmd.Flags().BoolP("update-shares", "s", false, "Will update any shares as part of rename")
+
+	datasetCmd.AddCommand(datasetCreateCmd)
+	datasetCmd.AddCommand(datasetUpdateCmd)
+	datasetCmd.AddCommand(datasetDeleteCmd)
+	datasetCmd.AddCommand(datasetListCmd)
+	datasetCmd.AddCommand(datasetPromoteCmd)
+	datasetCmd.AddCommand(datasetRenameCmd)
+	rootCmd.AddCommand(datasetCmd)
+}
+
+func createOrUpdateDataset(cmd *cobra.Command, api core.Session, args []string) error {
+	if api == nil {
+		return nil
+	}
+	defer api.Close()
+
+	cmdType := strings.Split(cmd.Use, " ")[0]
+	if cmdType != "create" && cmdType != "update" {
+		return errors.New("cmdType was not create or update")
+	}
+
+	params := make([]interface{}, 0)
+	outMap := make(map[string]interface{})
+
+	if cmdType == "create" {
+		outMap["name"] = args[0]
+	} else {
+		params = append(params, args[0])
+	}
+
+	options, err := GetCobraFlags(cmd, g_datasetCreateUpdateEnums)
+	if err != nil {
+		return err
+	}
+
+	var volSize int64
+	var userPropsStr string
+
+	for propName, valueStr := range options.usedFlags {
+		isProp := false
+		switch propName {
+		case "create_parents":
+			outMap["create_ancestors"] = valueStr == "true"
+		case "volume":
+			volSize, err = strconv.ParseInt(valueStr, 10, 64)
+			if err != nil {
+				return errors.New("Failed to parse volume size: " + err.Error())
+			}
+			if volSize < 0 {
+				return errors.New("Failed to parse volume size: negative numbers are not permitted")
+			}
+		case "user_props":
+			userPropsStr = valueStr
+		case "option":
+			kvArray := ConvertParamsStringToKvArray(valueStr)
+			if err = WriteKvArrayToMap(outMap, kvArray, g_datasetCreateUpdateEnums); err != nil {
+				return err
+			}
+		default:
+			isProp = true
+		}
+		if isProp {
+			value, err := ParseStringAndValidate(propName, valueStr, g_datasetCreateUpdateEnums)
+			if err != nil {
+				return err
+			}
+			outMap[propName] = value
+		}
+	}
+
+	if cmdType == "create" {
+		if volSize != 0 {
+			outMap["type"] = "VOLUME"
+			outMap["volsize"] = volSize
+		} else {
+			outMap["type"] = "FILESYSTEM"
+		}
+	} else if volSize != 0 {
+		outMap["volsize"] = volSize
+	}
+
+	if userPropsStr != "" {
+		kvParams := ConvertParamsStringToKvArray(userPropsStr)
+		userPropsArr := make([]map[string]interface{}, 0)
+		for i := 0; i < len(kvParams); i += 2 {
+			value, err := ParseStringAndValidate(kvParams[i], kvParams[i+1], g_datasetCreateUpdateEnums)
+			if err != nil {
+				return err
+			}
+			m := make(map[string]interface{})
+			m["key"] = kvParams[i]
+			m["value"] = value
+			userPropsArr = append(userPropsArr, m)
+		}
+		outMap["user_properties"] = userPropsArr
+	}
+
+	params = append(params, outMap)
+	DebugJson(params)
+
+	cmd.SilenceUsage = true
+
+	out, err := core.ApiCall(api, "pool.dataset."+cmdType, "10s", params)
+	if err != nil {
+		return err
+	}
+
+	DebugString(string(out))
+	return nil
+}
+
+func deleteDataset(cmd *cobra.Command, api core.Session, args []string) error {
+	if api == nil {
+		return nil
+	}
+	defer api.Close()
+
+	cmd.SilenceUsage = true
+
+	options, _ := GetCobraFlags(cmd, nil)
+	params := BuildNameStrAndPropertiesJson(options, args[0])
+	DebugJson(params)
+
+	out, err := core.ApiCall(api, "pool.dataset.delete", "10s", params)
+	if err != nil {
+		return err
+	}
+
+	DebugString(string(out))
+	return nil
+}
+
+func listDataset(cmd *cobra.Command, api core.Session, args []string) error {
+	if api == nil {
+		return nil
+	}
+	defer api.Close()
+
+	options, err := GetCobraFlags(cmd, g_datasetListEnums)
+	if err != nil {
+		return err
+	}
+
+	format, err := GetTableFormat(options.allFlags)
+	if err != nil {
+		return err
+	}
+
+	cmd.SilenceUsage = true
+
+	properties := EnumerateOutputProperties(options.allFlags)
+	idTypes, err := getDatasetListTypes(args)
+	if err != nil {
+		return err
+	}
+
+	// `zfs list` will "recurse" if no names are specified.
+	extras := typeRetrieveParams{
+		valueOrder:         BuildValueOrder(core.IsValueTrue(options.allFlags, "parseable")),
+		shouldGetAllProps:  core.IsValueTrue(options.allFlags, "all"),
+		shouldGetUserProps: core.IsValueTrue(options.allFlags, "user_properties"),
+		shouldRecurse:      len(args) == 0 || core.IsValueTrue(options.allFlags, "recursive"),
+	}
+
+	for _, prop := range properties {
+		if strings.Index(prop, ":") >= 0 {
+			extras.shouldGetUserProps = true
+			break
+		}
+	}
+
+	datasets, err := QueryApi(api, "dataset", args, idTypes, properties, extras)
+	if err != nil {
+		return err
+	}
+
+	LowerCaseValuesFromEnums(datasets, g_datasetCreateUpdateEnums)
+
+	required := []string{"name"}
+	var columnsList []string
+	if extras.shouldGetAllProps {
+		columnsList = GetUsedPropertyColumns(datasets, required)
+	} else if len(properties) > 0 {
+		columnsList = properties
+	} else {
+		columnsList = required
+	}
+
+	str, err := core.BuildTableData(format, "datasets", columnsList, datasets)
+	PrintTable(api, str)
+	return err
+}
+
+func promoteDataset(cmd *cobra.Command, api core.Session, args []string) error {
+	if api == nil {
+		return nil
+	}
+	defer api.Close()
+
+	cmd.SilenceUsage = true
+
+	params := []interface{}{args[0]}
+	DebugJson(params)
+
+	out, err := core.ApiCall(api, "pool.dataset.promote", "10s", params)
+	if err != nil {
+		return err
+	}
+
+	DebugString(string(out))
+	return nil
+}
+
+func renameDataset(cmd *cobra.Command, api core.Session, args []string) error {
+	if api == nil {
+		return nil
+	}
+	defer api.Close()
+
+	cmd.SilenceUsage = true
+
+	options, _ := GetCobraFlags(cmd, nil)
+
+	source := args[0]
+	dest := args[1]
+
+	outMap := make(map[string]interface{})
+	outMap["new_name"] = dest
+
+	params := []interface{}{source, outMap}
+	DebugJson(params)
+
+	out, err := core.ApiCall(api, "zfs.dataset.rename", "10s", params)
+	if err != nil {
+		return err
+	}
+	DebugString(string(out))
+
+	// no point updating the share if we're renaming a snapshot.
+	if core.IsValueTrue(options.allFlags, "update_shares") && !strings.Contains(source, "@") {
+		idStr, found, err := LookupNfsIdByPath(api, "/mnt/"+source, nil)
+		if err != nil {
+			return err
+		}
+		if !found {
+			fmt.Println("INFO: this dataset did not appear to have a share")
+			return nil
+		}
+		id, err := strconv.Atoi(idStr)
+		if err != nil {
+			return fmt.Errorf("Error updating share for dataset \"%s\", nfs id \"%s\": %v", dest, idStr, err)
+		}
+
+		pathMap := make(map[string]interface{})
+		pathMap["path"] = "/mnt/" + dest
+		nfsParams := []interface{}{id, pathMap}
+
+		DebugJson(nfsParams)
+
+		out, err = core.ApiCall(api, "sharing.nfs.update", "10s", nfsParams)
+		if err != nil {
+			return err
+		}
+		DebugString(string(out))
+	}
+
+	return err
+}
+
+func getDatasetListTypes(args []string) ([]string, error) {
+	var typeList []string
+	if len(args) == 0 {
+		return typeList, nil
+	}
+
+	typeList = make([]string, len(args), len(args))
+	for i := 0; i < len(args); i++ {
+		t, value := core.IdentifyObject(args[i])
+		if t == "id" || t == "share" {
+			return nil, errors.New("querying datasets based on mount point is not yet supported")
+		} else if t == "snapshot" || t == "snapshot_only" {
+			return nil, errors.New("querying datasets based on shapshot is not yet supported")
+		} else if t == "dataset" {
+			t = "name"
+		} else if t != "pool" {
+			return nil, errors.New("Unrecognised namespec \"" + args[i] + "\"")
+		}
+		typeList[i] = t
+		args[i] = value
+	}
+
+	return typeList, nil
+}

--- a/cmd/dataset_test.go
+++ b/cmd/dataset_test.go
@@ -1,0 +1,233 @@
+package cmd
+
+import (
+	"testing"
+)
+
+func TestDatasetCreateWithParentsTrue(t *testing.T) {
+	FailIf(t, DoSimpleTest(
+		t,
+		datasetCreateCmd,
+		createOrUpdateDataset,
+		map[string]interface{}{"create-parents":true},
+		[]string{"dozer/testing/test"},
+		"[{\"create_ancestors\":true,\"name\":\"dozer/testing/test\",\"type\":\"FILESYSTEM\"}]",
+	))
+}
+
+func TestDatasetCreateWithParentsFalse(t *testing.T) {
+	FailIf(t, DoSimpleTest(
+		t,
+		datasetCreateCmd,
+		createOrUpdateDataset,
+		map[string]interface{}{"create-parents":false},
+		[]string{"dozer/testing/test"},
+		"[{\"create_ancestors\":false,\"name\":\"dozer/testing/test\",\"type\":\"FILESYSTEM\"}]",
+	))
+}
+
+func TestDatasetCreateWithParentsEmpty(t *testing.T) {
+	FailIf(t, DoSimpleTest(
+		t,
+		datasetCreateCmd,
+		createOrUpdateDataset,
+		map[string]interface{}{"create-parents":""},
+		[]string{"dozer/testing/test"},
+		"aux flag create_parents: type mismatch (existing: bool, type of given value: string)",
+	))
+}
+
+func TestDatasetCreateWithComma(t *testing.T) {
+	FailIf(t, DoSimpleTest(
+		t,
+		datasetCreateCmd,
+		createOrUpdateDataset,
+		map[string]interface{}{},
+		[]string{"dozer/testing/test,comma"},
+		"[{\"name\":\"dozer/testing/test,comma\",\"type\":\"FILESYSTEM\"}]",
+	))
+}
+
+func TestDatasetCreateVolume(t *testing.T) {
+	FailIf(t, DoSimpleTest(
+		t,
+		datasetCreateCmd,
+		createOrUpdateDataset,
+		map[string]interface{}{"volume":1024},
+		[]string{"dozer/testing/test2"},
+		"[{\"name\":\"dozer/testing/test2\",\"type\":\"VOLUME\",\"volsize\":1024}]",
+	))
+}
+
+func TestDatasetCreateWithComments(t *testing.T) {
+	FailIf(t, DoSimpleTest(
+		t,
+		datasetCreateCmd,
+		createOrUpdateDataset,
+		map[string]interface{}{
+			"option":"exec=on,atime=off,acltype=posix,aclmode=discard",
+			"managedby":"incus.truenas",
+			"comments":"Managed by Incus.TrueNAS",
+		},
+		[]string{"dozer/testing/test"},
+		"[{\"aclmode\":\"DISCARD\",\"acltype\":\"POSIX\",\"atime\":\"OFF\","+
+			"\"comments\":\"Managed by Incus.TrueNAS\",\"exec\":\"ON\","+
+			"\"managedby\":\"incus.truenas\",\"name\":\"dozer/testing/test\",\"type\":\"FILESYSTEM\"}]",
+	))
+}
+
+func TestDatasetUpdate(t *testing.T) {
+	FailIf(t, DoSimpleTest(
+		t,
+		datasetUpdateCmd,
+		createOrUpdateDataset,
+		map[string]interface{}{
+			"option":"exec=off,atime=off,acltype=posix,aclmode=discard",
+			"managedby":"incus.truenas",
+			"comments":"Managed by Incus.TrueNAS",
+		},
+		[]string{"dozer/testing/test"},
+		"[\"dozer/testing/test\",{\"aclmode\":\"DISCARD\",\"acltype\":\"POSIX\","+
+			"\"atime\":\"OFF\",\"comments\":\"Managed by Incus.TrueNAS\","+
+			"\"exec\":\"OFF\",\"managedby\":\"incus.truenas\"}]",
+	))
+}
+
+func TestDatasetDelete(t *testing.T) {
+	FailIf(t, DoSimpleTest(
+		t,
+		datasetDeleteCmd,
+		deleteDataset,
+		map[string]interface{}{},
+		[]string{"dozer/testing/test"},
+		"[\"dozer/testing/test\",{}]",
+	))
+}
+
+func TestDatasetDeleteRecursive(t *testing.T) {
+	FailIf(t, DoSimpleTest(
+		t,
+		datasetDeleteCmd,
+		deleteDataset,
+		map[string]interface{}{"recursive":true},
+		[]string{"dozer/testing/test"},
+		"[\"dozer/testing/test\",{\"recursive\":true}]",
+	))
+}
+
+func TestDatasetDeleteForce(t *testing.T) {
+	FailIf(t, DoSimpleTest(
+		t,
+		datasetDeleteCmd,
+		deleteDataset,
+		map[string]interface{}{"force":true},
+		[]string{"dozer/testing/test"},
+		"[\"dozer/testing/test\",{\"force\":true}]",
+	))
+}
+
+func TestDatasetDeleteRecursiveForce(t *testing.T) {
+	FailIf(t, DoSimpleTest(
+		t,
+		datasetDeleteCmd,
+		deleteDataset,
+		map[string]interface{}{"recursive":true,"force":true},
+		[]string{"dozer/testing/test"},
+		"[\"dozer/testing/test\",{\"force\":true,\"recursive\":true}]",
+	))
+}
+
+func TestDatasetList(t *testing.T) {
+	FailIf(t, DoTest(
+		t,
+		datasetListCmd,
+		listDataset,
+		map[string]interface{}{},
+		[]string{"dozer/testing/test"},
+		[]string{"[[[\"name\",\"in\",[\"dozer/testing/test\"]]],{\"extra\":{\"flat\":false,"+ // expected
+			"\"properties\":[],\"retrieve_children\":false,\"user_properties\":false}}]"},
+		[]string{"{\"jsonrpc\":\"2.0\",\"result\":[{\"id\":\"dozer/testing/test\",\"name\":\"dozer/testing/test\"}],\"id\":2}"}, //response
+		"        name        \n" + // table
+		"--------------------\n" +
+		" dozer/testing/test \n",
+	))
+}
+
+func TestDatasetListRecursive(t *testing.T) {
+	FailIf(t, DoTest(
+		t,
+		datasetListCmd,
+		listDataset,
+		map[string]interface{}{"recursive":true},
+		[]string{"dozer/testing"},
+		[]string{"[[[\"name\",\"in\",[\"dozer/testing\"]]],{\"extra\":{\"flat\":false,"+ // expected
+			"\"properties\":[],\"retrieve_children\":true,\"user_properties\":false}}]"},
+		[]string{"{\"jsonrpc\":\"2.0\",\"result\":[{\"id\":\"dozer/testing\",\"name\":\"dozer/testing\"},"+
+			"{\"id\":\"dozer/testing/test\",\"name\":\"dozer/testing/test\"}],\"id\":2}"}, //response
+		"        name        \n" + // table
+		"--------------------\n" +
+		" dozer/testing      \n" +
+		" dozer/testing/test \n",
+	))
+}
+
+func TestDatasetListWithProperties(t *testing.T) {
+	FailIf(t, DoTest(
+		t,
+		datasetListCmd,
+		listDataset,
+		map[string]interface{}{"parseable":true,"output":"name,atime,exec"},
+		[]string{"dozer/testing/test"},
+		[]string{"[[[\"name\",\"in\",[\"dozer/testing/test\"]]],{\"extra\":{\"flat\":false,"+
+			"\"properties\":[\"name\",\"atime\",\"exec\"],\"retrieve_children\":false,\"user_properties\":false}}]"},
+		[]string{"{\"jsonrpc\":\"2.0\",\"result\":[{\"id\":\"dozer/testing/test\",\"name\":\"dozer/testing/test\","+
+			"\"properties\":{\"atime\":{\"rawvalue\":\"off\",\"value\":\"OFF\",\"parsed\":false},"+
+			"\"exec\":{\"rawvalue\":\"off\",\"value\":\"OFF\",\"parsed\":false}}}],\"id\":2}"},
+		"        name        | atime | exec \n" +
+		"--------------------+-------+------\n" +
+		" dozer/testing/test | off   | off  \n",
+	))
+}
+
+func TestDatasetPromote(t *testing.T) {
+	FailIf(t, DoSimpleTest(
+		t,
+		datasetPromoteCmd,
+		promoteDataset,
+		map[string]interface{}{},
+		[]string{"dozer/testing/test"},
+		"[\"dozer/testing/test\"]",
+	))
+}
+
+func TestDatasetRename(t *testing.T) {
+	FailIf(t, DoSimpleTest(
+		t,
+		datasetRenameCmd,
+		renameDataset,
+		map[string]interface{}{},
+		[]string{"dozer/testing/test", "dozer/testing/test3"},
+		"[\"dozer/testing/test\",{\"new_name\":\"dozer/testing/test3\"}]",
+	))
+}
+
+func TestDatasetRenameUpdateShares(t *testing.T) {
+	FailIf(t, DoTest(
+		t,
+		datasetRenameCmd,
+		renameDataset,
+		map[string]interface{}{"update-shares":true},
+		[]string{"dozer/testing/test", "dozer/testing/test3"},
+		[]string{ // expect
+			"[\"dozer/testing/test\",{\"new_name\":\"dozer/testing/test3\"}]",
+			"[[[\"path\",\"in\",[\"/mnt/dozer/testing/test\"]]]]",
+			"[1,{\"path\":\"/mnt/dozer/testing/test3\"}]",
+		},
+		[]string{ // response
+			"{}",
+			"{\"jsonrpc\":\"2.0\",\"result\":[{\"id\":1,\"path\":\"dozer/testing/test\"}],\"id\":2}",
+			"{}",
+		},
+		"", // table expected
+	))
+}

--- a/cmd/list.go
+++ b/cmd/list.go
@@ -1,0 +1,277 @@
+package cmd
+
+import (
+	"errors"
+	"fmt"
+	"slices"
+	"strings"
+	"truenas/truenas-admin/core"
+
+	"github.com/spf13/cobra"
+)
+
+var listCmd = &cobra.Command{
+	Use:   "list",
+	Short: "Prints a table of datasets/snapshots/shares, given a source and an optional set of properties.",
+}
+
+var g_genericListEnums map[string][]string
+
+func init() {
+	listCmd.RunE = func(cmd *cobra.Command, args []string) error {
+		return doList(cmd, ValidateAndLogin(), args)
+	}
+
+	g_genericListEnums = make(map[string][]string)
+
+	listCmd.Flags().StringP("types", "t", "fs,vol", "Array of types of data to retrieve. By default, types are deduced from arguments, else fs,vol. (fs,vol,snap,nfs)")
+	listCmd.Flags().BoolP("recursive", "r", false, "Retrieves properties for children")
+	listCmd.Flags().BoolP("json", "j", false, "Equivalent to --format=json")
+	listCmd.Flags().BoolP("no-headers", "H", false, "Equivalent to --format=compact. More easily parsed by scripts")
+	listCmd.Flags().String("format", "table", "Output table format. Defaults to \"table\" "+
+		AddFlagsEnum(&g_genericListEnums, "format", []string{"csv", "json", "table", "compact"}))
+	listCmd.Flags().StringP("output", "o", "", "Output property list")
+	listCmd.Flags().BoolP("parseable", "p", false, "Show raw values instead of the already parsed values")
+	listCmd.Flags().BoolP("all", "a", false, "Output all properties")
+
+	rootCmd.AddCommand(listCmd)
+}
+
+func doList(cmd *cobra.Command, api core.Session, args []string) error {
+	if api == nil {
+		return nil
+	}
+	defer api.Close()
+
+	options, err := GetCobraFlags(cmd, g_genericListEnums)
+	if err != nil {
+		return err
+	}
+
+	format, err := GetTableFormat(options.allFlags)
+	if err != nil {
+		return err
+	}
+
+	properties := EnumerateOutputProperties(options.allFlags)
+
+	givenTypes := strings.Split(options.allFlags["types"], ",")
+	if len(givenTypes) == 0 {
+		return errors.New("At least one object type must be provided")
+	}
+
+	typesToQuery := make(map[string]bool)
+	shouldQueryFs := false
+	shouldQueryVol := false
+	_, shouldExclude := options.usedFlags["types"]
+	if len(args) == 0 {
+		shouldExclude = true
+	}
+
+	for i := 0; i < len(givenTypes); i++ {
+		t := givenTypes[i]
+		if t == "fs" || t == "filesystem" {
+			t = "dataset"
+			shouldQueryFs = true
+		} else if t == "vol" || t == "volume" {
+			t = "dataset"
+			shouldQueryVol = true
+		} else if t == "snap" {
+			t = "snapshot"
+		}
+		if t != "dataset" && t != "snapshot" && t != "nfs" {
+			return errors.New("Unrecognised object type \"" + t + "\"")
+		}
+		typesToQuery[t] = true
+	}
+
+	qEntriesMap := make(map[string][]string)
+	qEntryTypesMap := make(map[string][]string)
+
+	for i := 0; i < len(args); i++ {
+		obj, value := core.IdentifyObject(args[i])
+		var qType string
+		if obj == "id" || obj == "share" {
+			qType = "nfs"
+		} else if obj == "snapshot" || obj == "snapshot_only" {
+			qType = "snapshot"
+		} else if obj == "dataset" {
+			qType = "dataset"
+		} else if obj == "pool" {
+			qType = "pool"
+		} else {
+			return errors.New("Unrecognised namespec \"" + obj + "\"")
+		}
+		if _, exists := qEntriesMap[qType]; !exists {
+			qEntriesMap[qType] = make([]string, 0)
+			qEntryTypesMap[qType] = make([]string, 0)
+		}
+		qEntriesMap[qType] = append(qEntriesMap[qType], value)
+		qEntryTypesMap[qType] = append(qEntryTypesMap[qType], obj)
+	}
+
+	// NOTE: datasets are added to snapshots before pools are added to datasets
+	if _, exists := typesToQuery["snapshot"]; exists || !shouldExclude {
+		addEntriesFromInto(qEntriesMap, qEntryTypesMap, "dataset", "snapshot", len(args) == 0)
+		addEntriesFromInto(qEntriesMap, qEntryTypesMap, "pool", "snapshot", len(args) == 0)
+	} else if shouldExclude {
+		delete(qEntriesMap, "snapshot")
+		delete(qEntryTypesMap, "snapshot")
+	}
+
+	if _, exists := typesToQuery["dataset"]; exists || !shouldExclude {
+		addEntriesFromInto(qEntriesMap, qEntryTypesMap, "pool", "dataset", len(args) == 0)
+	} else if shouldExclude {
+		delete(qEntriesMap, "dataset")
+		delete(qEntryTypesMap, "dataset")
+	}
+
+	if _, exists := typesToQuery["nfs"]; exists || !shouldExclude {
+		if len(args) == 0 {
+			qEntriesMap["nfs"] = make([]string, 0)
+			qEntryTypesMap["nfs"] = make([]string, 0)
+		}
+	} else {
+		delete(qEntriesMap, "nfs")
+		delete(qEntryTypesMap, "nfs")
+	}
+
+	delete(qEntriesMap, "pool")
+	delete(qEntryTypesMap, "pool")
+
+	tDs := qEntryTypesMap["dataset"]
+	for i, _ := range tDs {
+		if tDs[i] == "dataset" {
+			tDs[i] = "name"
+		}
+	}
+
+	tSnaps := qEntryTypesMap["snapshot"]
+	for i, _ := range tSnaps {
+		if tSnaps[i] == "snapshot" {
+			tSnaps[i] = "name"
+		} else if tSnaps[i] == "snapshot_only" {
+			tSnaps[i] = "snapshot_name"
+		}
+	}
+
+	tShares := qEntryTypesMap["nfs"]
+	for i, _ := range tShares {
+		if tShares[i] == "share" {
+			tShares[i] = "path"
+		}
+	}
+
+	DebugString(fmt.Sprint(typesToQuery))
+	DebugString(fmt.Sprint(qEntriesMap))
+	DebugString(fmt.Sprint(qEntryTypesMap))
+
+	var allTypes []string
+	for qType, _ := range qEntriesMap {
+		if allTypes == nil {
+			allTypes = make([]string, 0)
+		}
+		allTypes = append(allTypes, qType)
+	}
+
+	if len(allTypes) == 0 {
+		return errors.New("No types could be queried. Try passing a different value to the --types option.")
+	}
+
+	slices.Sort(allTypes)
+
+	cmd.SilenceUsage = true
+
+	var outProps []string
+	if properties != nil {
+		outProps = make([]string, len(properties))
+		copy(outProps, properties)
+		hasType := false
+		for _, p := range properties {
+			if p == "type" {
+				hasType = true
+				break
+			}
+		}
+		if !hasType {
+			properties = append(properties, "type")
+		}
+	}
+
+	extras := typeRetrieveParams{
+		valueOrder:         BuildValueOrder(core.IsValueTrue(options.allFlags, "parseable")),
+		shouldGetAllProps:  core.IsValueTrue(options.allFlags, "all"),
+		shouldGetUserProps: false,
+		shouldRecurse:      len(args) == 0 || core.IsValueTrue(options.allFlags, "recursive"),
+	}
+
+	allResults := make([]map[string]interface{}, 0)
+
+	for qType, qValues := range qEntriesMap {
+		results, err := QueryApi(api, qType, qValues, qEntryTypesMap[qType], properties, extras)
+		if err != nil {
+			return err
+		}
+
+		if qType == "dataset" {
+			filterType := ""
+			if shouldQueryFs && !shouldQueryVol {
+				filterType = "FILESYSTEM"
+			} else if !shouldQueryFs && shouldQueryVol {
+				filterType = "VOLUME"
+			}
+			if filterType != "" {
+				fResults := make([]map[string]interface{}, 0)
+				for _, r := range results {
+					if t, exists := r["type"]; exists && t == filterType {
+						fResults = append(fResults, r)
+					}
+				}
+				results = fResults
+			}
+		} else if qType == "nfs" {
+			for _, r := range results {
+				r["type"] = "nfs"
+			}
+		}
+
+		allResults = append(allResults, results...)
+	}
+
+	required := []string{"id"}
+	if _, exists := qEntriesMap["nfs"]; exists {
+		required = append(required, "path")
+	}
+
+	LowerCaseValuesFromEnums(allResults, g_datasetCreateUpdateEnums)
+	//LowerCaseValuesFromEnums(allResults, g_snapshotCreateUpdateEnums)
+	LowerCaseValuesFromEnums(allResults, g_nfsCreateUpdateEnums)
+
+	var columnsList []string
+	if extras.shouldGetAllProps {
+		columnsList = GetUsedPropertyColumns(allResults, required)
+	} else if len(properties) > 0 {
+		columnsList = outProps
+	} else {
+		columnsList = required
+	}
+
+	str, err := core.BuildTableData(format, "all", columnsList, allResults)
+	PrintTable(api, str)
+	return err
+}
+
+func addEntriesFromInto(allValues, allTypes map[string][]string, srcKey, dstKey string, shouldCreateAnyway bool) {
+	if _, exists := allValues[dstKey]; !exists && shouldCreateAnyway {
+		allValues[dstKey] = make([]string, 0)
+		allTypes[dstKey] = make([]string, 0)
+	}
+	if values, exists := allValues[srcKey]; exists {
+		if _, exists := allValues[dstKey]; !exists {
+			allValues[dstKey] = make([]string, 0)
+			allTypes[dstKey] = make([]string, 0)
+		}
+		allValues[dstKey] = append(allValues[dstKey], values...)
+		allTypes[dstKey] = append(allTypes[dstKey], allTypes[srcKey]...)
+	}
+}

--- a/cmd/list_test.go
+++ b/cmd/list_test.go
@@ -1,0 +1,56 @@
+package cmd
+
+import (
+	"testing"
+)
+
+func TestGenericList(t *testing.T) {
+	FailIf(t, DoTest(
+		t,
+		listCmd,
+		doList,
+		map[string]interface{}{"no-headers":true,"parseable":true,"output":"id,clones"},
+		[]string{},
+		[]string{"[[],{\"extra\":{\"flat\":false,\"properties\":[\"id\",\"clones\",\"type\"],\"retrieve_children\":true,\"user_properties\":false}}]"},
+		[]string{"{\"jsonrpc\":\"2.0\",\"result\":[{\"id\":\"dozer/testing/test4@readonly\",\"name\":\"dozer/testing/test4@readonly\","+
+			"\"properties\":{\"clones\":{\"rawvalue\":\"dozer/testing/test5\",\"value\":\"dozer/testing/test5\",\"parsed\":\"dozer/testing/test5\"}}}],\"id\":2}"},
+		"dozer/testing/test4@readonly\tdozer/testing/test5\n",
+	))
+}
+
+func TestGenericListTypes(t *testing.T) {
+	
+}
+
+func TestGenericListParameters(t *testing.T) {
+	
+}
+
+func TestGenericListParametersRecursive(t *testing.T) {
+	FailIf(t, DoTest(
+		t,
+		listCmd,
+		doList,
+		map[string]interface{}{"recursive":true,"no-headers":true,"parseable":true,"output":"id,clones"},
+		[]string{"dozer/testing"},
+		[]string{ // expected
+			"[[[\"name\",\"in\",[\"dozer/testing\"]]],"+
+				"{\"extra\":{\"flat\":false,\"properties\":[\"id\",\"clones\",\"type\"],\"retrieve_children\":true,\"user_properties\":false}}]",
+			"[[[\"OR\",[[\"dataset\",\"=\",\"dozer/testing\"],[\"dataset\",\"^\",\"dozer/testing/\"]]]],"+
+				"{\"extra\":{\"flat\":false,\"properties\":[\"id\",\"clones\",\"type\"],\"retrieve_children\":true,\"user_properties\":false}}]",
+		},
+		[]string{ // response
+			"{\"jsonrpc\":\"2.0\",\"result\":[{\"id\":\"dozer/testing/test\",\"name\":\"dozer/testing/test\"},"+
+				"{\"id\":\"dozer/testing/test5\",\"name\":\"dozer/testing/test5\"}],\"id\":2}",
+			"{\"jsonrpc\":\"2.0\",\"result\":[{\"id\":\"dozer/testing/test4@readonly\",\"name\":\"dozer/testing/test4@readonly\","+
+				"\"properties\":{\"clones\":{\"rawvalue\":\"dozer/testing/test5\",\"value\":\"dozer/testing/test5\",\"parsed\":\"dozer/testing/test5\"}}}],\"id\":2}",
+		},
+		"dozer/testing/test\t-\n"+
+		"dozer/testing/test5\t-\n"+
+		"dozer/testing/test4@readonly\tdozer/testing/test5\n",
+	))
+}
+
+func TestGenericListTypesAndParameters(t *testing.T) {
+
+}

--- a/cmd/nfs.go
+++ b/cmd/nfs.go
@@ -1,0 +1,419 @@
+package cmd
+
+import (
+	"errors"
+	"fmt"
+	"strconv"
+	"truenas/truenas-admin/core"
+
+	"github.com/spf13/cobra"
+)
+
+var nfsCmd = &cobra.Command{
+	Use:   "nfs",
+	Short: "Create, list, update or delete NFS shares",
+	Run: func(cmd *cobra.Command, args []string) {
+		if len(args) == 0 {
+			cmd.HelpFunc()(cmd, args)
+			return
+		}
+	},
+}
+
+var nfsCreateCmd = &cobra.Command{
+	Use:   "create [flags] <dataset|path>",
+	Short: "Creates a nfs share.",
+	Args:  cobra.MinimumNArgs(1),
+}
+
+var nfsUpdateCmd = &cobra.Command{
+	Use:     "update [flags] <id|dataset|path>",
+	Short:   "Updates an existing nfs share.",
+	Args:    cobra.MinimumNArgs(1),
+	Aliases: []string{"set"},
+}
+
+var nfsDeleteCmd = &cobra.Command{
+	Use:     "delete [flags] <id|dataset|path>",
+	Short:   "Deletes an nfs share.",
+	Args:    cobra.MinimumNArgs(1),
+	Aliases: []string{"rm"},
+}
+
+var nfsListCmd = &cobra.Command{
+	Use:     "list [flags] [path]...", // TODO: add dataset support
+	Short:   "Prints a table of all nfs shares, given a source and an optional set of properties.",
+	Aliases: []string{"ls"},
+}
+
+var g_nfsCreateUpdateEnums map[string][]string
+var g_nfsListEnums map[string][]string
+
+func init() {
+	nfsCreateCmd.RunE = func(cmd *cobra.Command, args []string) error {
+		return createNfs(cmd, ValidateAndLogin(), args)
+	}
+
+	nfsUpdateCmd.RunE = func(cmd *cobra.Command, args []string) error {
+		return updateNfs(cmd, ValidateAndLogin(), args)
+	}
+
+	nfsDeleteCmd.RunE = func(cmd *cobra.Command, args []string) error {
+		return deleteNfs(cmd, ValidateAndLogin(), args)
+	}
+
+	nfsListCmd.RunE = func(cmd *cobra.Command, args []string) error {
+		return listNfs(cmd, ValidateAndLogin(), args)
+	}
+
+	nfsUpdateCmd.Flags().String("path", "", "Mount path")
+
+	g_nfsCreateUpdateEnums = make(map[string][]string)
+
+	createUpdateCmds := []*cobra.Command{nfsCreateCmd, nfsUpdateCmd}
+	for _, cmd := range createUpdateCmds {
+		cmd.Flags().Bool("read-only", false, "Export as write protected, default false")
+		cmd.Flags().Bool("ro", false, "Equivalent to --read-only=true")
+		cmd.Flags().String("comment", "", "")
+		cmd.Flags().String("networks", "", "A list of authorized networks that are allowed to access the share "+
+			"using CIDR notation. If empty, all networks are allowed")
+		cmd.Flags().String("hosts", "", "List of hosts")
+		cmd.Flags().String("maproot-user", "", "")
+		cmd.Flags().String("maproot-group", "", "")
+		cmd.Flags().String("mapall-user", "", "")
+		cmd.Flags().String("mapall-group", "", "")
+		cmd.Flags().String("security", "", "Array of Enum(sys,krb5,krb5i,krb5p)")
+		cmd.Flags().Bool("enabled", false, "")
+	}
+
+	nfsUpdateCmd.Flags().BoolP("create", "c", false, "If the share doesn't exist, create it. Off by default.")
+
+	g_nfsCreateUpdateEnums["security"] = []string{"sys", "krb5", "krb5i", "krb5p"}
+
+	nfsListCmd.Flags().BoolP("json", "j", false, "Equivalent to --format=json")
+	nfsListCmd.Flags().BoolP("no-headers", "H", false, "Equivalent to --format=compact. More easily parsed by scripts")
+	nfsListCmd.Flags().String("format", "table", "Output table format. Defaults to \"table\" "+
+		AddFlagsEnum(&g_nfsListEnums, "format", []string{"csv", "json", "table", "compact"}))
+	nfsListCmd.Flags().StringP("output", "o", "", "Output property list")
+	nfsListCmd.Flags().BoolP("parseable", "p", false, "Show raw values instead of the already parsed values")
+	nfsListCmd.Flags().BoolP("all", "a", false, "Output all properties")
+
+	nfsCmd.AddCommand(nfsCreateCmd)
+	nfsCmd.AddCommand(nfsUpdateCmd)
+	nfsCmd.AddCommand(nfsDeleteCmd)
+	nfsCmd.AddCommand(nfsListCmd)
+
+	shareCmd.AddCommand(nfsCmd)
+}
+
+func createNfs(cmd *cobra.Command, api core.Session, args []string) error {
+	if api == nil {
+		return nil
+	}
+	defer api.Close()
+
+	var sharePath string
+	typeStr, spec := core.IdentifyObject(args[0])
+
+	switch typeStr {
+	case "dataset":
+		sharePath = "/mnt/" + spec
+	case "share":
+		sharePath = spec
+	default:
+		return errors.New("Unrecognized nfs create spec \"" + spec + "\"")
+	}
+
+	options, _ := GetCobraFlags(cmd, nil)
+
+	options.usedFlags["path"] = sharePath
+	options.allTypes["path"] = "string"
+
+	propsMap, err := writeNfsCreateUpdateProperties(options)
+	if err != nil {
+		return err
+	}
+
+	params := []interface{}{propsMap}
+	DebugJson(params)
+
+	cmd.SilenceUsage = true
+
+	out, err := core.ApiCall(api, "sharing.nfs.create", "10s", params)
+	if err != nil {
+		return err
+	}
+
+	DebugString(string(out))
+	return nil
+}
+
+func updateNfs(cmd *cobra.Command, api core.Session, args []string) error {
+	if api == nil {
+		return nil
+	}
+	defer api.Close()
+
+	var sharePath string
+	var idStr string
+	typeStr, spec := core.IdentifyObject(args[0])
+
+	switch typeStr {
+	case "id":
+		idStr = spec
+	case "dataset":
+		sharePath = "/mnt/" + spec
+	case "share":
+		sharePath = spec
+	default:
+		return errors.New("Unrecognized nfs update spec \"" + spec + "\"")
+	}
+
+	options, _ := GetCobraFlags(cmd, nil)
+
+	shouldCreate := false
+	var existingProperties map[string]string
+
+	if idStr == "" {
+		var found bool
+		var err error
+		existingProperties = make(map[string]string)
+		idStr, found, err = LookupNfsIdByPath(api, sharePath, existingProperties)
+		if err != nil {
+			cmd.SilenceUsage = true
+			return err
+		}
+		if !found {
+			if core.IsValueTrue(options.allFlags, "create") {
+				shouldCreate = true
+			} else {
+				cmd.SilenceUsage = true
+				return errors.New("Could not find NFS share \"" + sharePath + "\".\n" +
+					"Try passing -c to create a share if it doesn't exist.")
+			}
+		}
+	}
+
+	// now that we know whether to create or not, let's not pass this flag on to the API
+	delete(options.usedFlags, "create")
+	delete(options.allFlags, "create")
+
+	params := make([]interface{}, 0)
+
+	if shouldCreate {
+		options.usedFlags["path"] = sharePath
+		options.allTypes["path"] = "string"
+	} else {
+		id, err := strconv.Atoi(idStr)
+		if err != nil {
+			return fmt.Errorf("Failed to parse NFS share id: %v", err)
+		}
+		if id < 0 {
+			return fmt.Errorf("NFS share id was not valid (%d)", id)
+		}
+		if existingProperties != nil {
+			anyDiffs := false
+			for key, value := range options.usedFlags {
+				if elem, exists := existingProperties[key]; exists {
+					if elem != value {
+						anyDiffs = true
+						break
+					}
+				} else {
+					// this flag is not an existing property of this nfs share
+					anyDiffs = true
+					break
+				}
+			}
+			if !anyDiffs {
+				DebugString("share does not require updating, exiting")
+				return nil
+			}
+		}
+		params = append(params, id)
+	}
+
+	propsMap, err := writeNfsCreateUpdateProperties(options)
+	if err != nil {
+		return err
+	}
+
+	params = append(params, propsMap)
+	DebugJson(params)
+
+	var verb string
+	if shouldCreate {
+		verb = "create"
+	} else {
+		verb = "update"
+	}
+
+	cmd.SilenceUsage = true
+
+	out, err := core.ApiCall(api, "sharing.nfs."+verb, "10s", params)
+	if err != nil {
+		return err
+	}
+
+	DebugString(string(out))
+	return nil
+}
+
+func writeNfsCreateUpdateProperties(options FlagMap) (map[string]interface{}, error) {
+	outMap := make(map[string]interface{})
+	for propName, valueStr := range options.usedFlags {
+		if propName == "security" {
+			securityList, err := ValidateEnumArray(valueStr, []string{"sys", "krb5", "krb5i", "krb5p"})
+			if err != nil {
+				return nil, err
+			}
+			if securityList == nil {
+				securityList = make([]string, 0)
+			}
+			outMap["security"] = securityList
+		} else {
+			if propName == "read-only" {
+				propName = "ro"
+			}
+			value, err := ParseStringAndValidate(propName, valueStr, nil)
+			if err != nil {
+				return nil, err
+			}
+			outMap[propName] = value
+		}
+	}
+	return outMap, nil
+}
+
+func deleteNfs(cmd *cobra.Command, api core.Session, args []string) error {
+	if api == nil {
+		return nil
+	}
+	defer api.Close()
+
+	var sharePath string
+	var idStr string
+	typeStr, spec := core.IdentifyObject(args[0])
+
+	switch typeStr {
+	case "id":
+		idStr = spec
+	case "dataset":
+		sharePath = "/mnt/" + spec
+	case "share":
+		sharePath = spec
+	default:
+		return errors.New("Unrecognized nfs create spec \"" + spec + "\"")
+	}
+
+	cmd.SilenceUsage = true
+
+	var err error
+	if idStr == "" {
+		var found bool
+		idStr, found, err = LookupNfsIdByPath(api, sharePath, nil)
+		if err != nil {
+			return err
+		}
+		if !found {
+			return errors.New("Could not find nfs share for path \"" + sharePath + "\"")
+		}
+	}
+
+	id, err := strconv.Atoi(idStr)
+	if err != nil {
+		return err
+	}
+	if id < 0 {
+		return fmt.Errorf("NFS share id was not valid (%d)", id)
+	}
+
+	params := []interface{}{id}
+	DebugJson(params)
+
+	out, err := core.ApiCall(api, "sharing.nfs.delete", "10s", params)
+	if err != nil {
+		return err
+	}
+
+	DebugString(string(out))
+	return nil
+}
+
+func listNfs(cmd *cobra.Command, api core.Session, args []string) error {
+	if api == nil {
+		return nil
+	}
+	defer api.Close()
+
+	options, err := GetCobraFlags(cmd, g_nfsListEnums)
+	if err != nil {
+		return err
+	}
+
+	format, err := GetTableFormat(options.allFlags)
+	if err != nil {
+		return err
+	}
+
+	cmd.SilenceUsage = true
+
+	properties := EnumerateOutputProperties(options.allFlags)
+	idTypes, err := getNfsListTypes(args)
+	if err != nil {
+		return err
+	}
+
+	extras := typeRetrieveParams{
+		valueOrder:         BuildValueOrder(core.IsValueTrue(options.allFlags, "parseable")),
+		shouldGetAllProps:  core.IsValueTrue(options.allFlags, "all"),
+		shouldGetUserProps: false,
+		shouldRecurse:      len(args) == 0 || core.IsValueTrue(options.allFlags, "recursive"),
+	}
+
+	shares, err := QueryApi(api, "nfs", args, idTypes, properties, extras)
+	if err != nil {
+		return err
+	}
+
+	LowerCaseValuesFromEnums(shares, g_nfsCreateUpdateEnums)
+
+	required := []string{"id", "path"}
+	var columnsList []string
+	if extras.shouldGetAllProps {
+		columnsList = GetUsedPropertyColumns(shares, required)
+	} else if len(properties) > 0 {
+		columnsList = properties
+	} else {
+		columnsList = required
+	}
+
+	str, err := core.BuildTableData(format, "shares", columnsList, shares)
+	PrintTable(api, str)
+	return err
+}
+
+func getNfsListTypes(args []string) ([]string, error) {
+	var typeList []string
+	if len(args) == 0 {
+		return typeList, nil
+	}
+
+	typeList = make([]string, len(args), len(args))
+	for i := 0; i < len(args); i++ {
+		t, value := core.IdentifyObject(args[i])
+		if t == "snapshot" || t == "snapshot_only" {
+			return nil, errors.New("querying nfs shares based on snapshot is not supported")
+		} else if t == "dataset" {
+			return nil, errors.New("querying nfs shares based on dataset is not yet supported")
+		} else if t == "share" {
+			t = "path"
+		} else if t != "id" && t != "pool" {
+			return nil, errors.New("Unrecognised namespec \"" + args[i] + "\"")
+		}
+		typeList[i] = t
+		args[i] = value
+	}
+
+	return typeList, nil
+}

--- a/cmd/nfs_test.go
+++ b/cmd/nfs_test.go
@@ -1,0 +1,27 @@
+package cmd
+
+import (
+	"testing"
+)
+
+func TestNfsCreate(t *testing.T) {
+	if false {
+		t.Fail()
+	}
+}
+
+func TestNfsUpdate(t *testing.T) {
+
+}
+
+func TestNfsUpdateOrCreate(t *testing.T) {
+
+}
+
+func TestNfsDelete(t *testing.T) {
+
+}
+
+func TestNfsList(t *testing.T) {
+
+}

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -1,0 +1,195 @@
+package cmd
+
+import (
+	"encoding/json"
+	"fmt"
+	"log"
+	"os"
+	"truenas/truenas-admin/core"
+
+	"github.com/spf13/cobra"
+)
+
+var rootCmd = &cobra.Command{
+	Use: "truenas-admin",
+}
+
+func Execute() {
+	err := rootCmd.Execute()
+	if err != nil {
+		os.Exit(1)
+	}
+}
+
+var g_useMock bool
+var g_debug bool
+var g_configFileName string
+var g_configHost string
+var g_url string
+var g_apiKey string
+
+func init() {
+	rootCmd.PersistentFlags().BoolVar(&g_debug, "debug", false, "Enable debug logs")
+	rootCmd.PersistentFlags().BoolVar(&g_useMock, "mock", false, "Use the mock API instead of a TrueNAS server")
+	rootCmd.PersistentFlags().StringVar(&g_configFileName, "config", "", "Override config filename (~/.truenas-admin/config.json)")
+	rootCmd.PersistentFlags().StringVar(&g_configHost, "host", "", "Name of config to look up in config.json, defaults to first entry")
+	rootCmd.PersistentFlags().StringVarP(&g_url, "url", "U", "", "Server URL")
+	rootCmd.PersistentFlags().StringVarP(&g_apiKey, "api-key", "K", "", "API key")
+}
+
+func RemoveGlobalFlags(flags map[string]string) {
+	delete(flags, "debug")
+	delete(flags, "mock")
+	delete(flags, "config")
+	delete(flags, "host")
+	delete(flags, "url")
+	delete(flags, "api-key")
+	delete(flags, "api_key")
+}
+
+func ValidateAndLogin() core.Session {
+	var api core.Session
+	if g_useMock {
+		api = &core.MockSession{
+			DatasetSource: &core.FileRawa{FileName: "datasets.tsv"},
+		}
+	} else {
+		if g_url == "" && g_apiKey == "" {
+			var err error
+			g_url, g_apiKey, err = loadConfig(g_configFileName, g_configHost)
+			if err != nil {
+				log.Fatal(fmt.Errorf("Failed to parse config: %v", err))
+			}
+		}
+		api = &core.RealSession{
+			HostUrl:     g_url,
+			ApiKey:      g_apiKey,
+		}
+	}
+
+	err := api.Login()
+	if err != nil {
+		api.Close()
+		log.Fatal(err)
+	}
+
+	return api
+}
+
+func loadConfig(fileName, hostName string) (string, string, error) {
+	var data []byte
+	var err error
+
+	if fileName == "" {
+		fileName = getDefaultConfigPath()
+		data, err = os.ReadFile(fileName)
+	} else {
+		data, err = os.ReadFile(fileName)
+		if err != nil {
+			fileName = getDefaultConfigPath()
+			data, err = os.ReadFile(fileName)
+		}
+	}
+
+	if err != nil {
+		return "", "", err
+	}
+
+	var obj interface{}
+	if err = json.Unmarshal(data, &obj); err != nil {
+		return "", "", fmt.Errorf("\"%s\": %v", fileName, err)
+	}
+
+	config, ok := obj.(map[string]interface{})
+	if !ok {
+		return "", "", fmt.Errorf("Config was not a JSON object \"%s\"", fileName)
+	}
+
+	hosts, err := getMapFromMapAny(config, "hosts", fileName)
+	if err != nil {
+		return "", "", err
+	}
+
+	if hostName == "" {
+		for key, _ := range hosts {
+			if hostName == "" || key < hostName {
+				hostName = key
+			}
+		}
+		if hostName == "" {
+			return "", "", fmt.Errorf("Could not find any hosts in config \"%s\"", fileName)
+		}
+	}
+
+	host, err := getMapFromMapAny(hosts, hostName, fileName)
+	if err != nil {
+		return "", "", err
+	}
+
+	apiKey, err := getNonEmptyStringFromMapAny(host, "api_key", fileName)
+	if err != nil {
+		return "", "", err
+	}
+
+	url, err := getNonEmptyStringFromMapAny(host, "url", fileName)
+	if err != nil {
+		return "", "", err
+	}
+
+	return url, apiKey, nil
+}
+
+func getDefaultConfigPath() string {
+	p, err := os.UserHomeDir()
+	if err != nil {
+		log.Fatal(err)
+	}
+	return p + "/.truenas-admin/config.json"
+}
+
+func getMapFromMapAny(dict map[string]interface{}, key, fileName string) (map[string]interface{}, error) {
+	var inner map[string]interface{}
+	if innerObj, exists := dict[key]; exists {
+		var ok bool
+		inner, ok = innerObj.(map[string]interface{})
+		if !ok {
+			return nil, fmt.Errorf("\"%s\" in config \"%s\" was not a JSON object", key, fileName)
+		}
+	} else {
+		return nil, fmt.Errorf("Could not find \"%s\" in config \"%s\"", key, fileName)
+	}
+	return inner, nil
+}
+
+func getNonEmptyStringFromMapAny(dict map[string]interface{}, key, fileName string) (string, error) {
+	var str string
+	if strObj, exists := dict[key]; exists {
+		var ok bool
+		str, ok = strObj.(string)
+		if !ok {
+			return "", fmt.Errorf("\"%s\" in config \"%s\" was not a string", key, fileName)
+		}
+	} else {
+		return "", fmt.Errorf("Could not find \"%s\" in config \"%s\"", key, fileName)
+	}
+	if str == "" {
+		return "", fmt.Errorf("\"%s\" in config \"%s\" was left blank", key, fileName)
+	}
+	return str, nil
+}
+
+func DebugString(str string) {
+	if g_debug {
+		fmt.Println(str)
+	}
+}
+
+func DebugJson(obj interface{}) {
+	if g_debug {
+		data, err := json.Marshal(obj)
+		if err != nil {
+			fmt.Printf("%v (%v)", obj, err)
+		}
+		fmt.Println(string(data))
+	}
+}

--- a/cmd/share.go
+++ b/cmd/share.go
@@ -1,0 +1,14 @@
+package cmd
+
+import (
+	"github.com/spf13/cobra"
+)
+
+var shareCmd = &cobra.Command{
+	Use:   "share",
+	Short: "Create, list, update or delete network shares. Currently only NFS is supported.",
+}
+
+func init() {
+	rootCmd.AddCommand(shareCmd)
+}

--- a/cmd/snapshot.go
+++ b/cmd/snapshot.go
@@ -1,0 +1,332 @@
+package cmd
+
+import (
+	"errors"
+	"strings"
+	"truenas/truenas-admin/core"
+
+	"github.com/spf13/cobra"
+)
+
+var snapshotCmd = &cobra.Command{
+	Use:   "snapshot",
+	Short: "Edit or list snapshots on a remote or local machine",
+	Run: func(cmd *cobra.Command, args []string) {
+		if len(args) == 0 {
+			cmd.HelpFunc()(cmd, args)
+			return
+		}
+	},
+}
+
+var snapshotCloneCmd = &cobra.Command{
+	Use:   "clone",
+	Short: "clone snapshot of ZFS dataset",
+	Args:  cobra.MinimumNArgs(2),
+}
+
+var snapshotCreateCmd = &cobra.Command{
+	Use:   "create [flags] <dataset>@<snapshot>",
+	Short: "Take a snapshot of dataset, possibly recursive",
+	Args:  cobra.MinimumNArgs(1),
+}
+
+var snapshotDeleteCmd = &cobra.Command{
+	Use:     "delete [flags] <dataset>@<snapshot>",
+	Short:   "Delete a snapshot of dataset, possibly recursive",
+	Args:    cobra.MinimumNArgs(1),
+	Aliases: []string{"rm"},
+}
+
+var snapshotListCmd = &cobra.Command{
+	Use:     "list [flags] [<dataset>][@<snapshot>]...",
+	Short:   "List all snapshots",
+	Aliases: []string{"ls"},
+}
+
+var snapshotRenameCmd = &cobra.Command{
+	Use:     "rename [flags] <old dataset>@<old snapshot> <new snapshot>",
+	Short:   "Rename a ZFS snapshot",
+	Args:    cobra.ExactArgs(2),
+	Aliases: []string{"mv"},
+}
+
+var snapshotRollbackCmd = &cobra.Command{
+	Use:   "rollback",
+	Short: "Rollback to a given snapshot",
+	Args:  cobra.MinimumNArgs(1),
+}
+
+var g_snapshotListEnums map[string][]string
+
+func init() {
+	snapshotCloneCmd.RunE = func(cmd *cobra.Command, args []string) error {
+		return cloneSnapshot(cmd, ValidateAndLogin(), args)
+	}
+
+	snapshotCreateCmd.RunE = func(cmd *cobra.Command, args []string) error {
+		return createSnapshot(cmd, ValidateAndLogin(), args)
+	}
+
+	snapshotDeleteCmd.RunE = func(cmd *cobra.Command, args []string) error {
+		return deleteOrRollbackSnapshot(cmd, ValidateAndLogin(), args)
+	}
+
+	snapshotListCmd.RunE = func(cmd *cobra.Command, args []string) error {
+		return listSnapshot(cmd, ValidateAndLogin(), args)
+	}
+
+	snapshotRenameCmd.RunE = func(cmd *cobra.Command, args []string) error {
+		return renameSnapshot(cmd, ValidateAndLogin(), args)
+	}
+
+	snapshotRollbackCmd.RunE = func(cmd *cobra.Command, args []string) error {
+		return deleteOrRollbackSnapshot(cmd, ValidateAndLogin(), args)
+	}
+
+	snapshotCreateCmd.Flags().BoolP("recursive", "r", false, "")
+	snapshotCreateCmd.Flags().String("exclude", "", "List of datasets to exclude")
+	snapshotCreateCmd.Flags().StringP("option", "o", "", "Specify property=value,...")
+	snapshotCreateCmd.Flags().Bool("suspend-vms", false, "")
+	snapshotCreateCmd.Flags().Bool("vmware-sync", false, "")
+
+	snapshotDeleteCmd.Flags().BoolP("recursive", "r", false, "recursively delete children")
+	snapshotDeleteCmd.Flags().Bool("defer", false, "defer the deletion of snapshot")
+
+	snapshotListCmd.Flags().BoolP("recursive", "r", false, "")
+	snapshotListCmd.Flags().BoolP("user-properties", "u", false, "Include user-properties")
+	snapshotListCmd.Flags().BoolP("json", "j", false, "Equivalent to --format=json")
+	snapshotListCmd.Flags().BoolP("no-headers", "H", false, "Equivalent to --format=compact. More easily parsed by scripts")
+	snapshotListCmd.Flags().String("format", "table", "Output table format. Defaults to \"table\" "+
+		AddFlagsEnum(&g_snapshotListEnums, "format", []string{"csv", "json", "table", "compact"}))
+	snapshotListCmd.Flags().StringP("output", "o", "", "Output property list")
+	snapshotListCmd.Flags().BoolP("parseable", "p", false, "Show raw values instead of the already parsed values")
+	snapshotListCmd.Flags().Bool("all", false, "Output all properties")
+
+	snapshotRollbackCmd.Flags().BoolP("force", "f", false, "force unmount of any clones")
+	snapshotRollbackCmd.Flags().BoolP("recursive", "r", false, "destroy any snapshots and bookmarks more recent than the one specified")
+	snapshotRollbackCmd.Flags().BoolP("recursive-clones", "R", false, "like recursive, but also destroy any clones")
+	snapshotRollbackCmd.Flags().Bool("recursive-rollback", false, "perform a completem recursive rollback of each child snapshots.\n"+
+		"If any child does not have specified snapshot, this operation will fail.")
+
+	snapshotCmd.AddCommand(snapshotCloneCmd)
+	snapshotCmd.AddCommand(snapshotCreateCmd)
+	snapshotCmd.AddCommand(snapshotDeleteCmd)
+	snapshotCmd.AddCommand(snapshotListCmd)
+	snapshotCmd.AddCommand(snapshotRenameCmd)
+	snapshotCmd.AddCommand(snapshotRollbackCmd)
+	rootCmd.AddCommand(snapshotCmd)
+}
+
+func cloneSnapshot(cmd *cobra.Command, api core.Session, args []string) error {
+	if api == nil {
+		return nil
+	}
+	defer api.Close()
+
+	cmd.SilenceUsage = true
+
+	outMap := make(map[string]interface{})
+	outMap["snapshot"] = args[0]
+	outMap["dataset_dst"] = args[1]
+	//outMap["dataset_properties"] = make(map[string]interface{})
+
+	params := []interface{}{outMap}
+	DebugJson(params)
+
+	out, err := core.ApiCall(api, "zfs.snapshot.clone", "10s", params)
+	if err != nil {
+		return err
+	}
+
+	DebugString(string(out))
+	return nil
+}
+
+func createSnapshot(cmd *cobra.Command, api core.Session, args []string) error {
+	if api == nil {
+		return nil
+	}
+	defer api.Close()
+
+	options, _ := GetCobraFlags(cmd, nil)
+
+	snapshot := args[0]
+	datasetLen := strings.Index(snapshot, "@")
+	if datasetLen <= 0 || datasetLen == len(snapshot)-1 {
+		return errors.New("No dataset name was found in snapshot specifier.\nExpected <datasetname>@<snapshotname>.")
+	}
+	dataset := snapshot[0:datasetLen]
+
+	snapshotIsolated := snapshot[datasetLen+1:]
+
+	outMap := make(map[string]interface{})
+
+	outMap["dataset"] = dataset
+	outMap["name"] = snapshotIsolated
+
+	MaybeCopyProperty(outMap, options.allFlags, "recursive")
+	MaybeCopyProperty(outMap, options.usedFlags, "suspend_vms")
+	MaybeCopyProperty(outMap, options.usedFlags, "vmware_sync")
+
+	if excludeStr := options.allFlags["exclude"]; excludeStr != "" {
+		outMap["exclude"] = strings.Split(excludeStr, ",")
+	}
+
+	// TODO: naming_schema
+
+	outProps := make(map[string]interface{})
+	_ = WriteKvArrayToMap(outProps, ConvertParamsStringToKvArray(options.allFlags["option"]), nil)
+	outMap["properties"] = outProps
+
+	params := []interface{}{outMap}
+	DebugJson(params)
+
+	cmd.SilenceUsage = true
+
+	out, err := core.ApiCall(api, "zfs.snapshot.create", "10s", params)
+	if err != nil {
+		return err
+	}
+
+	DebugString(string(out))
+	return nil
+}
+
+func deleteOrRollbackSnapshot(cmd *cobra.Command, api core.Session, args []string) error {
+	if api == nil {
+		return nil
+	}
+	defer api.Close()
+
+	cmdType := strings.Split(cmd.Use, " ")[0]
+	if cmdType != "delete" && cmdType != "rollback" {
+		return errors.New("cmdType was not delete or rollback")
+	}
+
+	snapshot := args[0]
+	datasetLen := strings.Index(snapshot, "@")
+	if datasetLen <= 0 {
+		return errors.New("No dataset name was found in snapshot specifier.\nExpected <datasetname>@<snapshotname>.")
+	}
+
+	options, _ := GetCobraFlags(cmd, nil)
+	params := BuildNameStrAndPropertiesJson(options, snapshot)
+	DebugJson(params)
+
+	cmd.SilenceUsage = true
+
+	out, err := core.ApiCall(api, "zfs.snapshot."+cmdType, "10s", params)
+	if err != nil {
+		return err
+	}
+
+	DebugString(string(out))
+	return nil
+}
+
+func renameSnapshot(cmd *cobra.Command, api core.Session, args []string) error {
+	if api == nil {
+		return nil
+	}
+	defer api.Close()
+
+	cmd.SilenceUsage = true
+
+	source := args[0]
+	dest := args[1]
+
+	outMap := make(map[string]interface{})
+	outMap["new_name"] = dest
+
+	params := []interface{}{source, outMap}
+	DebugJson(params)
+
+	// For now, snapshot rename uses the same API as dataset rename. This may change in the future.
+	out, err := core.ApiCall(api, "zfs.dataset.rename", "10s", params)
+	if err != nil {
+		return err
+	}
+
+	DebugString(string(out))
+	return nil
+}
+
+func listSnapshot(cmd *cobra.Command, api core.Session, args []string) error {
+	if api == nil {
+		return nil
+	}
+	defer api.Close()
+
+	options, err := GetCobraFlags(cmd, g_snapshotListEnums)
+	if err != nil {
+		return err
+	}
+
+	format, err := GetTableFormat(options.allFlags)
+	if err != nil {
+		return err
+	}
+
+	cmd.SilenceUsage = true
+
+	properties := EnumerateOutputProperties(options.allFlags)
+	idTypes, err := getSnapshotListTypes(args)
+	if err != nil {
+		return err
+	}
+
+	// `zfs list` will "recurse" if no names are specified.
+	extras := typeRetrieveParams{
+		valueOrder:         BuildValueOrder(core.IsValueTrue(options.allFlags, "parseable")),
+		shouldGetAllProps:  core.IsValueTrue(options.allFlags, "all"),
+		shouldGetUserProps: false,
+		shouldRecurse:      len(args) == 0 || core.IsValueTrue(options.allFlags, "recursive"),
+	}
+
+	snapshots, err := QueryApi(api, "snapshot", args, idTypes, properties, extras)
+	if err != nil {
+		return err
+	}
+
+	//LowerCaseValuesFromEnums(snapshots, g_snapshotCreateUpdateEnums)
+
+	required := []string{"name"}
+	var columnsList []string
+	if extras.shouldGetAllProps {
+		columnsList = GetUsedPropertyColumns(snapshots, required)
+	} else if len(properties) > 0 {
+		columnsList = properties
+	} else {
+		columnsList = required
+	}
+
+	str, err := core.BuildTableData(format, "snapshots", columnsList, snapshots)
+	PrintTable(api, str)
+	return err
+}
+
+func getSnapshotListTypes(args []string) ([]string, error) {
+	var typeList []string
+	if len(args) == 0 {
+		return typeList, nil
+	}
+
+	typeList = make([]string, len(args), len(args))
+	for i := 0; i < len(args); i++ {
+		t, value := core.IdentifyObject(args[i])
+		if t == "id" || t == "share" {
+			return nil, errors.New("querying snapshots based on mount point is not yet supported")
+		} else if t == "snapshot" {
+			t = "name"
+		} else if t == "snapshot_only" {
+			t = "snapshot_name"
+		} else if t != "dataset" && t != "pool" {
+			return nil, errors.New("Unrecognised namespec \"" + args[i] + "\"")
+		}
+		typeList[i] = t
+		args[i] = value
+	}
+
+	return typeList, nil
+}

--- a/cmd/snapshot_test.go
+++ b/cmd/snapshot_test.go
@@ -1,0 +1,190 @@
+package cmd
+
+import (
+	"testing"
+)
+
+func TestSnapshotClone(t *testing.T) {
+	FailIf(t, DoSimpleTest(
+		t,
+		snapshotCloneCmd,
+		cloneSnapshot,
+		map[string]interface{}{},
+		[]string{"dozer/testing/test4@readonly","dozer/testing/test5@readonly"},
+		"[{\"dataset_dst\":\"dozer/testing/test5@readonly\",\"snapshot\":\"dozer/testing/test4@readonly\"}]",
+	))
+}
+
+func TestSnapshotCreate(t *testing.T) {
+	FailIf(t, DoSimpleTest(
+		t,
+		snapshotCreateCmd,
+		createSnapshot,
+		map[string]interface{}{},
+		[]string{"dozer/testing/test4@readonly"},
+		"[{\"dataset\":\"dozer/testing/test4\",\"name\":\"readonly\",\"properties\":{},\"recursive\":false}]",
+	))
+}
+
+func TestSnapshotCreateFlags(t *testing.T) {
+	FailIf(t, DoSimpleTest(
+		t,
+		snapshotCreateCmd,
+		createSnapshot,
+		map[string]interface{}{"recursive":true,"suspend_vms":true,"vmware_sync":false,"exclude":"dozer/testing/test5","option":"readonly=ON"},
+		[]string{"dozer/testing/test4@readonly"},
+		"[{\"dataset\":\"dozer/testing/test4\",\"exclude\":[\"dozer/testing/test5\"],\"name\":\"readonly\","+
+			"\"properties\":{\"readonly\":\"ON\"},\"recursive\":true,\"suspend_vms\":true,\"vmware_sync\":false}]",
+	))
+}
+
+func TestSnapshotDelete(t *testing.T) {
+	FailIf(t, DoSimpleTest(
+		t,
+		snapshotDeleteCmd,
+		deleteOrRollbackSnapshot,
+		map[string]interface{}{},
+		[]string{"dozer/testing/test3@readonly"},
+		"[\"dozer/testing/test3@readonly\",{}]",
+	))
+}
+
+func TestSnapshotList(t *testing.T) {
+	FailIf(t, DoTest(
+		t,
+		snapshotListCmd,
+		listSnapshot,
+		map[string]interface{}{},
+		[]string{},
+		[]string{"[[],{\"extra\":{\"flat\":false,\"properties\":[],\"retrieve_children\":true,\"user_properties\":false}}]"}, // expected
+		[]string{"{\"jsonrpc\":\"2.0\",\"result\":[{\"id\":\"dozer/testing/test4@readonly\",\"name\":\"dozer/testing/test4@readonly\"},"+ //response
+			"{\"id\":\"dozer/testing/test5@readonly\",\"name\":\"dozer/testing/test5@readonly\"}],\"id\":2}"},
+		"             name             \n" + // table
+		"------------------------------\n" +
+		" dozer/testing/test4@readonly \n" +
+		" dozer/testing/test5@readonly \n",
+	))
+}
+
+func TestSnapshotListParameter(t *testing.T) {
+	FailIf(t, DoTest(
+		t,
+		snapshotListCmd,
+		listSnapshot,
+		map[string]interface{}{},
+		[]string{"dozer/testing/test4@readonly"},
+		[]string{"[[[\"name\",\"in\",[\"dozer/testing/test4@readonly\"]]],"+ // expected
+			"{\"extra\":{\"flat\":false,\"properties\":[],\"retrieve_children\":false,\"user_properties\":false}}]"},
+		[]string{"{\"jsonrpc\":\"2.0\",\"result\":[{\"id\":\"dozer/testing/test4@readonly\",\"name\":\"dozer/testing/test4@readonly\"}],\"id\":2}"}, // response
+		"             name             \n" + // table
+		"------------------------------\n" +
+		" dozer/testing/test4@readonly \n",
+	))
+}
+
+func TestSnapshotListTwoParameters(t *testing.T) {
+	FailIf(t, DoTest(
+		t,
+		snapshotListCmd,
+		listSnapshot,
+		map[string]interface{}{},
+		[]string{"dozer/testing/test4@readonly","dozer/testing/test5@readonly"},
+		[]string{"[[[\"name\",\"in\",[\"dozer/testing/test4@readonly\",\"dozer/testing/test5@readonly\"]]],"+ // expected
+			"{\"extra\":{\"flat\":false,\"properties\":[],\"retrieve_children\":false,\"user_properties\":false}}]"},
+		[]string{"{\"jsonrpc\":\"2.0\",\"result\":[{\"id\":\"dozer/testing/test4@readonly\",\"name\":\"dozer/testing/test4@readonly\"},"+ //response
+			"{\"id\":\"dozer/testing/test5@readonly\",\"name\":\"dozer/testing/test5@readonly\"}],\"id\":2}"},
+		"             name             \n" + // table
+		"------------------------------\n" +
+		" dozer/testing/test4@readonly \n" +
+		" dozer/testing/test5@readonly \n",
+	))
+}
+
+func TestSnapshotListDataset(t *testing.T) {
+	FailIf(t, DoTest(
+		t,
+		snapshotListCmd,
+		listSnapshot,
+		map[string]interface{}{},
+		[]string{"dozer/testing/test4"},
+		[]string{"[[[\"dataset\",\"in\",[\"dozer/testing/test4\"]]],{\"extra\":{\"flat\":false,"+ // expected
+			"\"properties\":[],\"retrieve_children\":false,\"user_properties\":false}}]"},
+		[]string{"{\"jsonrpc\":\"2.0\",\"result\":[{\"id\":\"dozer/testing/test4@readonly\",\"name\":\"dozer/testing/test4@readonly\"}],\"id\":2}"}, // response
+		"             name             \n" + // table
+		"------------------------------\n" +
+		" dozer/testing/test4@readonly \n",
+	))
+}
+
+func TestSnapshotListSnapshot(t *testing.T) {
+	FailIf(t, DoTest(
+		t,
+		snapshotListCmd,
+		listSnapshot,
+		map[string]interface{}{},
+		[]string{"@readonly"},
+		[]string{"[[[\"snapshot_name\",\"in\",[\"readonly\"]]],{\"extra\":{\"flat\":false,"+ // expected
+			"\"properties\":[],\"retrieve_children\":false,\"user_properties\":false}}]"},
+		[]string{"{\"jsonrpc\":\"2.0\",\"result\":[{\"id\":\"dozer/testing/test4@readonly\",\"name\":\"dozer/testing/test4@readonly\"},"+ //response
+			"{\"id\":\"dozer/testing/test5@readonly\",\"name\":\"dozer/testing/test5@readonly\"}],\"id\":2}"},
+		"             name             \n" + // table
+		"------------------------------\n" +
+		" dozer/testing/test4@readonly \n" +
+		" dozer/testing/test5@readonly \n",
+	))
+}
+
+func TestSnapshotListRecursive(t *testing.T) {
+	FailIf(t, DoTest(
+		t,
+		snapshotListCmd,
+		listSnapshot,
+		map[string]interface{}{"recursive":true},
+		[]string{"dozer/testing"},
+		[]string{"[[[\"OR\",[[\"dataset\",\"=\",\"dozer/testing\"],[\"dataset\",\"^\",\"dozer/testing/\"]]]],"+ // expected
+			"{\"extra\":{\"flat\":false,\"properties\":[],\"retrieve_children\":true,\"user_properties\":false}}]"},
+		[]string{"{\"jsonrpc\":\"2.0\",\"result\":[{\"id\":\"dozer/testing/test4@readonly\",\"name\":\"dozer/testing/test4@readonly\"},"+ //response
+			"{\"id\":\"dozer/testing/test5@readonly\",\"name\":\"dozer/testing/test5@readonly\"}],\"id\":2}"},
+		"             name             \n" + // table
+		"------------------------------\n" +
+		" dozer/testing/test4@readonly \n" +
+		" dozer/testing/test5@readonly \n",
+	))
+}
+
+func TestSnapshotListWithProperties(t *testing.T) {
+	FailIf(t, DoTest(
+		t,
+		snapshotListCmd,
+		listSnapshot,
+		map[string]interface{}{"no-headers":true,"parseable":true,"output":"name,clones"},
+		[]string{"dozer/testing/test4@readonly"},
+		[]string{"[[[\"name\",\"in\",[\"dozer/testing/test4@readonly\"]]],{\"extra\":{\"flat\":false,"+
+			"\"properties\":[\"name\",\"clones\"],\"retrieve_children\":false,\"user_properties\":false}}]"},
+		[]string{"{\"jsonrpc\":\"2.0\",\"result\":[{\"id\":\"dozer/testing/test4@readonly\",\"name\":\"dozer/testing/test4@readonly\","+
+			"\"properties\":{\"clones\":{\"rawvalue\":\"dozer/testing/test\",\"value\":\"dozer/testing/test\",\"parsed\":\"dozer/testing/test\"}}}],\"id\":2}"},
+		"dozer/testing/test4@readonly\tdozer/testing/test\n",
+	))
+}
+
+func TestSnapshotRename(t *testing.T) {
+	FailIf(t, DoSimpleTest(
+		t,
+		snapshotRenameCmd,
+		renameSnapshot,
+		map[string]interface{}{},
+		[]string{"dozer/testing/test@readonly", "dozer/testing/test3@readonly"},
+		"[\"dozer/testing/test@readonly\",{\"new_name\":\"dozer/testing/test3@readonly\"}]",
+	))
+}
+
+func TestSnapshotRollback(t *testing.T) {
+	FailIf(t, DoSimpleTest(
+		t,
+		snapshotRollbackCmd,
+		deleteOrRollbackSnapshot,
+		map[string]interface{}{},
+		[]string{"dozer/testing/test3@readonly"},
+		"[\"dozer/testing/test3@readonly\",{}]",
+	))
+}

--- a/cmd/util_common.go
+++ b/cmd/util_common.go
@@ -1,0 +1,488 @@
+package cmd
+
+import (
+	"encoding/json"
+	"errors"
+	"fmt"
+	"math"
+
+	//"os"
+	//"log"
+	"slices"
+	"strconv"
+	"strings"
+	"truenas/truenas-admin/core"
+)
+
+type typeRetrieveParams struct {
+	valueOrder         []string
+	shouldGetAllProps  bool
+	shouldGetUserProps bool
+	shouldRecurse      bool
+}
+
+func BuildNameStrAndPropertiesJson(options FlagMap, nameStr string) []interface{} {
+	outMap := make(map[string]interface{})
+	for key, value := range options.usedFlags {
+		parsed, _ := ParseStringAndValidate(key, value, nil)
+		outMap[key] = parsed
+	}
+
+	return []interface{}{nameStr, outMap}
+}
+
+func QueryApi(api core.Session, endpointType string, entries, entryTypes, propsList []string, params typeRetrieveParams) ([]map[string]interface{}, error) {
+	var endpoint string
+	switch endpointType {
+	case "dataset":
+		endpoint = "pool.dataset.query"
+	case "snapshot":
+		endpoint = "zfs.snapshot.query"
+	case "nfs":
+		endpoint = "sharing.nfs.query"
+	default:
+		return nil, fmt.Errorf("unrecognised retrieve format \"%s\"", endpointType)
+	}
+
+	if len(entryTypes) != len(entries) {
+		return nil, fmt.Errorf("length mismatch between entries and entry types: %d != %d", len(entries), len(entryTypes))
+	}
+
+	filter, err := makeQueryFilter(entries, entryTypes, params)
+	if err != nil {
+		return nil, err
+	}
+
+	query := []interface{}{filter}
+	if endpointType != "nfs" {
+		query = append(query, makeQueryOptions(propsList, params))
+	}
+
+	DebugJson(query)
+
+	data, err := core.ApiCall(api, endpoint, "20s", query)
+	if err != nil {
+		return nil, err
+	}
+
+	//fmt.Println(string(data))
+	//os.Stdout.WriteString(string(data))
+	//fmt.Println("\n")
+
+	var response interface{}
+	if err = json.Unmarshal(data, &response); err != nil {
+		return nil, fmt.Errorf("response error: %v", err)
+	}
+
+	responseMap, ok := response.(map[string]interface{})
+	if !ok {
+		return nil, errors.New("API response was not a JSON object")
+	}
+
+	resultsList, errMsg := core.ExtractJsonArrayOfMaps(responseMap, "result")
+	if errMsg != "" {
+		return nil, errors.New("API response results: " + errMsg)
+	}
+	if len(resultsList) == 0 {
+		DebugString("resultsList was empty")
+		return nil, nil
+	}
+
+	outputMap := make(map[string]map[string]interface{})
+	outputMapIntKeys := make([]int, 0, 0)
+	outputMapStrKeys := make([]string, 0, 0)
+
+	// Do not refactor this loop condition into a range!
+	// This loop modifies the size of resultsList as it iterates.
+	for i := 0; i < len(resultsList); i++ {
+		children, _ := core.ExtractJsonArrayOfMaps(resultsList[i], "children")
+		if len(children) > 0 {
+			resultsList = append(resultsList, children...)
+		}
+
+		var primary string
+		if primaryValue, ok := resultsList[i]["id"]; ok {
+			if primaryStr, ok := primaryValue.(string); ok {
+				primary = primaryStr
+			} else {
+				primary = fmt.Sprint(primaryValue)
+			}
+		}
+		if len(primary) == 0 {
+			continue
+		}
+		if _, exists := outputMap[primary]; exists {
+			continue
+		}
+
+		dict := make(map[string]interface{})
+		dict["id"] = primary
+
+		if endpointType == "nfs" {
+			dict["type"] = "NFS"
+		}
+
+		insertProperties(dict, resultsList[i], []string{"id", "children", "properties"}, params.valueOrder)
+		if innerProps, exists := resultsList[i]["properties"]; exists {
+			if innerPropsMap, ok := innerProps.(map[string]interface{}); ok {
+				insertProperties(dict, innerPropsMap, nil, params.valueOrder)
+			}
+		}
+		if innerProps, exists := resultsList[i]["user_properties"]; exists {
+			if innerPropsMap, ok := innerProps.(map[string]interface{}); ok {
+				insertProperties(dict, innerPropsMap, nil, params.valueOrder)
+			}
+		}
+
+		outputMap[primary] = dict
+		if primaryInt, errNotNumber := strconv.Atoi(primary); errNotNumber == nil {
+			outputMapIntKeys = append(outputMapIntKeys, primaryInt)
+		} else {
+			outputMapStrKeys = append(outputMapStrKeys, primary)
+		}
+	}
+
+	slices.Sort(outputMapIntKeys)
+	slices.Sort(outputMapStrKeys)
+	nKeys := len(outputMapIntKeys) + len(outputMapStrKeys)
+
+	outputList := make([]map[string]interface{}, nKeys, nKeys)
+	for i, _ := range outputMapIntKeys {
+		outputList[i] = outputMap[strconv.Itoa(outputMapIntKeys[i])]
+	}
+	for i, _ := range outputMapStrKeys {
+		outputList[len(outputMapIntKeys)+i] = outputMap[outputMapStrKeys[i]]
+	}
+
+	return outputList, nil
+}
+
+func makeQueryFilter(entries, entryTypes []string, params typeRetrieveParams) ([]interface{}, error) {
+	for i, e := range entries {
+		if e == "" {
+			return nil, fmt.Errorf("Cannot query based on empty %s", entryTypes[i])
+		}
+	}
+
+	filter := make([]interface{}, 0)
+
+	// first arg = query-filter
+	if len(entries) == 1 {
+		filter = append(filter, makeIndividualFilter(entryTypes[0], []string{entries[0]}, params.shouldRecurse))
+	} else if len(entries) > 1 {
+		typeEntriesMap := make(map[string][]string)
+		uniqTypes := make([]string, 0, 0)
+		for i := 0; i < len(entries); i++ {
+			if _, exists := typeEntriesMap[entryTypes[i]]; !exists {
+				typeEntriesMap[entryTypes[i]] = make([]string, 0, 0)
+				uniqTypes = append(uniqTypes, entryTypes[i])
+			}
+			typeEntriesMap[entryTypes[i]] = append(typeEntriesMap[entryTypes[i]], entries[i])
+		}
+
+		filterList := make([][]interface{}, len(uniqTypes))
+		for i := 0; i < len(uniqTypes); i++ {
+			filterList[i] = makeIndividualFilter(uniqTypes[i], typeEntriesMap[uniqTypes[i]], params.shouldRecurse)
+		}
+
+		filter = append(filter, constructORChain(filterList))
+	}
+
+	return filter, nil
+}
+
+func makeIndividualFilter(key string, array []string, isRecursive bool) []interface{} {
+	if isRecursive && (key == "dataset" /* || key == "pool"*/) {
+		return constructORChain(makeRecursivePathsFilterList(key, array))
+	}
+	return []interface{}{key, "in", array}
+}
+
+func makeRecursivePathsFilterList(key string, paths []string) [][]interface{} {
+	filterList := make([][]interface{}, 0)
+	for i := 0; i < len(paths); i++ {
+		filterList = append(filterList, []interface{}{key, "=", paths[i]})
+		filterList = append(filterList, []interface{}{key, "^", paths[i] + "/"})
+	}
+	return filterList
+}
+
+func constructORChain(filterList [][]interface{}) []interface{} {
+	nFilters := len(filterList)
+	if nFilters == 0 {
+		return nil
+	}
+	top := [][]interface{}{filterList[0]}
+	for i := 1; i < nFilters; i++ {
+		top = append(top, filterList[i])
+		inner := []interface{}{"OR", top}
+		top = [][]interface{}{inner}
+	}
+	return top[0]
+}
+
+func makeQueryOptions(propsList []string, params typeRetrieveParams) map[string]interface{} {
+	// second arg = query-options
+	options := make(map[string]interface{})
+	options["flat"] = false
+	options["retrieve_children"] = params.shouldRecurse
+	if params.shouldGetAllProps {
+		var nothing interface{}
+		options["properties"] = nothing
+	} else {
+		if propsList == nil {
+			propsList = make([]string, 0)
+		}
+		options["properties"] = propsList
+	}
+	options["user_properties"] = params.shouldGetUserProps
+	return map[string]interface{}{"extra": options}
+}
+
+func insertProperties(dstMap, srcMap map[string]interface{}, excludeKeys []string, valueOrder []string) {
+	for key, value := range srcMap {
+		if _, exists := dstMap[key]; exists {
+			continue
+		}
+		shouldSkip := false
+		for _, ex := range excludeKeys {
+			if key == ex {
+				shouldSkip = true
+				break
+			}
+		}
+		if shouldSkip {
+			continue
+		}
+
+		var elem interface{}
+		if valueMap, ok := value.(map[string]interface{}); ok {
+			for _, t := range valueOrder {
+				if actualValue, ok := valueMap[t]; ok {
+					elem = actualValue
+					break
+				}
+			}
+
+		} else {
+			elem = value
+		}
+
+		if elem != nil {
+			if elemFloat, ok := elem.(float64); ok {
+				if elemFloat == math.Floor(elemFloat) {
+					elem = int64(elemFloat)
+				}
+			}
+			dstMap[key] = elem
+		}
+	}
+}
+
+func BuildValueOrder(parseable bool) []string {
+	if parseable {
+		return []string{"value", "rawvalue", "parsed"}
+	}
+	return []string{"parsed", "value", "rawvalue"}
+}
+
+func LowerCaseValuesFromEnums(results []map[string]interface{}, enums map[string][]string) {
+	for i, _ := range results {
+		for key, _ := range enums {
+			if value, exists := results[i][key]; exists {
+				if valueStr, ok := value.(string); ok {
+					results[i][key] = strings.ToLower(valueStr)
+				}
+			}
+		}
+	}
+}
+
+func LookupNfsIdByPath(api core.Session, sharePath string, optShareProperties map[string]string) (string, bool, error) {
+	if sharePath == "" {
+		return "", false, errors.New("Error looking up NFS share: no path was specified")
+	}
+
+	extras := typeRetrieveParams{
+		valueOrder:         BuildValueOrder(false),
+		shouldGetAllProps:  optShareProperties != nil,
+		shouldGetUserProps: optShareProperties != nil,
+		shouldRecurse:      false,
+	}
+
+	shares, err := QueryApi(api, "nfs", []string{sharePath}, []string{"path"}, []string{"id", "path"}, extras)
+	if err != nil {
+		return "", false, errors.New("API error: " + fmt.Sprint(err))
+	}
+	if len(shares) == 0 {
+		return "", false, nil
+	}
+
+	var idStr string
+	if value, exists := shares[0]["id"]; exists {
+		if valueStr, ok := value.(string); ok {
+			if _, errNotNumber := strconv.Atoi(valueStr); errNotNumber == nil {
+				idStr = valueStr
+			}
+		} else {
+			idStr = fmt.Sprint(value)
+		}
+	}
+	if idStr == "" {
+		return "", false, nil
+	}
+
+	if optShareProperties != nil {
+		for key, value := range shares[0] {
+			if valueStr, ok := value.(string); ok {
+				optShareProperties[key] = valueStr
+			} else {
+				optShareProperties[key] = fmt.Sprint(value)
+			}
+		}
+	}
+
+	return idStr, true, nil
+}
+
+func ConvertParamsStringToKvArray(fullParamsStr string) []string {
+	if fullParamsStr == "" {
+		return nil
+	}
+
+	kvArray := make([]string, 0)
+	params := strings.Split(fullParamsStr, ",")
+	for _, parameter := range params {
+		parts := strings.Split(parameter, "=")
+		if len(parts) == 0 || parts[0] == "" {
+			continue
+		}
+		var value string
+		if len(parts) == 1 || parts[1] == "" {
+			value = "true"
+		} else {
+			value = parts[1]
+		}
+		kvArray = append(kvArray, parts[0], value)
+	}
+
+	return kvArray
+}
+
+func WriteKvArrayToMap(dstMap map[string]interface{}, kvArray []string, enumsList map[string][]string) error {
+	for i := 0; i < len(kvArray); i += 2 {
+		key := kvArray[i]
+		value, err := ParseStringAndValidate(key, kvArray[i+1], enumsList)
+		if err != nil {
+			return err
+		}
+		dstMap[key] = value
+	}
+	return nil
+}
+
+func ParseStringAndValidate(optKey, value string, optEnumsList map[string][]string) (interface{}, error) {
+	if value == "true" || value == "false" {
+		return value == "true", nil
+	} else if value == "null" {
+		return nil, nil
+	} else if intValue, errNotInteger := strconv.Atoi(value); errNotInteger == nil {
+		return intValue, nil
+	} else if floatValue, errNotFloat := strconv.ParseFloat(value, 64); errNotFloat == nil {
+		return floatValue, nil
+	} else {
+		if optKey != "" && optEnumsList != nil {
+			if acceptable, exists := optEnumsList[optKey]; exists {
+				found := false
+				valueUpper := strings.ToUpper(value)
+				for i := 0; i < len(acceptable); i++ {
+					if valueUpper == strings.ToUpper(acceptable[i]) {
+						found = true
+						break
+					}
+				}
+				if !found {
+					return nil, fmt.Errorf("Could not find value %s in enum %s %v", value, optKey, acceptable)
+				}
+				return valueUpper, nil
+			}
+		}
+	}
+	return value, nil
+}
+
+func MaybeCopyProperty(dstMap map[string]interface{}, srcMap map[string]string, key string) {
+	if valueStr, exists := srcMap[key]; exists {
+		dstMap[key], _ = ParseStringAndValidate(key, valueStr, nil)
+	}
+}
+
+func EnumerateOutputProperties(properties map[string]string) []string {
+	propsStr, exists := properties["output"]
+	if !exists || propsStr == "" {
+		return nil
+	}
+
+	var propsList []string
+	if len(propsStr) > 0 {
+		propsList = strings.Split(propsStr, ",")
+	}
+	return propsList
+}
+
+func MakePropertyColumns(required []string, additional []string) []string {
+	columnSet := make(map[string]bool)
+	uniqAdditional := make([]string, 0, 0)
+
+	for _, c := range required {
+		columnSet[c] = true
+	}
+	for _, c := range additional {
+		if _, exists := columnSet[c]; !exists {
+			uniqAdditional = append(uniqAdditional, c)
+		}
+		columnSet[c] = true
+	}
+
+	slices.Sort(uniqAdditional)
+
+	if len(required) > 0 {
+		return append(required, uniqAdditional...)
+	}
+	return uniqAdditional
+}
+
+func GetUsedPropertyColumns[T any](data []map[string]T, required []string) []string {
+	columnsMap := make(map[string]bool)
+	columnsList := make([]string, 0)
+
+	for _, c := range required {
+		columnsMap[c] = true
+	}
+
+	for _, d := range data {
+		for key, _ := range d {
+			if _, exists := columnsMap[key]; !exists {
+				columnsMap[key] = true
+				columnsList = append(columnsList, key)
+			}
+		}
+	}
+
+	slices.Sort(columnsList)
+	return append(required, columnsList...)
+}
+
+func GetTableFormat(properties map[string]string) (string, error) {
+	isJson := core.IsValueTrue(properties, "json")
+	isCompact := core.IsValueTrue(properties, "no_headers")
+	if isJson && isCompact {
+		return "", errors.New("--json and --no_headers cannot be used together")
+	} else if isJson {
+		return "json", nil
+	} else if isCompact {
+		return "compact", nil
+	}
+
+	return properties["format"], nil
+}

--- a/cmd/util_flags.go
+++ b/cmd/util_flags.go
@@ -1,0 +1,184 @@
+package cmd
+
+import (
+	"errors"
+	"fmt"
+	"strings"
+
+	"github.com/spf13/cobra"
+	"github.com/spf13/pflag"
+)
+
+type FlagMap struct {
+	flagKeys  []string
+	usedFlags map[string]string
+	allFlags  map[string]string
+	allTypes  map[string]string
+}
+
+var auxiliaryFlags map[*cobra.Command]map[string]interface{}
+
+func SetAuxCobraFlag(cmd *cobra.Command, rawKey string, parsedValue interface{}) {
+	if auxiliaryFlags == nil {
+		auxiliaryFlags = make(map[*cobra.Command]map[string]interface{})
+	}
+	if flags, exists := auxiliaryFlags[cmd]; !exists || flags == nil {
+		auxiliaryFlags[cmd] = make(map[string]interface{})
+	}
+	key := strings.ReplaceAll(rawKey, "-", "_")
+	auxiliaryFlags[cmd][key] = parsedValue
+}
+
+func ResetAuxCobraFlags(cmd *cobra.Command) {
+	if auxiliaryFlags != nil {
+		auxiliaryFlags[cmd] = nil
+	}
+}
+
+func GetCobraFlags(cmd *cobra.Command, cmdEnums map[string][]string) (FlagMap, error) {
+	fm := FlagMap{}
+	fm.usedFlags = make(map[string]string)
+	cmd.Flags().Visit(func(flag *pflag.Flag) {
+		key := strings.ReplaceAll(flag.Name, "-", "_")
+		fm.usedFlags[key] = flag.Value.String()
+	})
+
+	fm.flagKeys = make([]string, 0)
+	fm.allFlags = make(map[string]string)
+	fm.allTypes = make(map[string]string)
+	cmd.Flags().VisitAll(func(flag *pflag.Flag) {
+		key := strings.ReplaceAll(flag.Name, "-", "_")
+		fm.flagKeys = append(fm.flagKeys, key)
+		fm.allFlags[key] = flag.Value.String()
+		fm.allTypes[key] = flag.Value.Type()
+	})
+
+	if aux, exists := auxiliaryFlags[cmd]; exists {
+		for key, value := range aux {
+			knownType, exists := fm.allTypes[key]
+			if !exists {
+				return FlagMap{}, fmt.Errorf("aux flag %s was not found in command \"%s\"", key, cmd.Use)
+			}
+			var typeStr string
+			if _, ok := value.(string); ok {
+				typeStr = "string"
+			} else if _, ok := value.(bool); ok {
+				typeStr = "bool"
+			} else if _, ok := value.(int); ok {
+				typeStr = "int"
+			} else if _, ok := value.(int64); ok {
+				typeStr = "int64"
+			} else {
+				typeStr = "any"
+			}
+			if knownType[:3] != typeStr[:3] {
+				return FlagMap{}, fmt.Errorf("aux flag %s: type mismatch (existing: %s, type of given value: %s)", key, knownType, typeStr)
+			}
+			valueStr := fmt.Sprint(value)
+			fm.allFlags[key] = valueStr
+			fm.usedFlags[key] = valueStr
+		}
+	}
+
+	RemoveGlobalFlags(fm.usedFlags)
+	RemoveGlobalFlags(fm.allFlags)
+	RemoveGlobalFlags(fm.allTypes)
+
+	if err := ValidateFlagEnums(&fm.usedFlags, cmdEnums); err != nil {
+		return FlagMap{}, err
+	}
+	if err := ValidateFlagEnums(&fm.allFlags, cmdEnums); err != nil {
+		return FlagMap{}, err
+	}
+	return fm, nil
+}
+
+func InsertNonCobraFlag(fm FlagMap, flagType, flagName, flagValue string) {
+	key := strings.ReplaceAll(flagName, "-", "_")
+	fm.flagKeys = append(fm.flagKeys, key)
+	fm.usedFlags[key] = flagValue
+	fm.allFlags[key] = flagValue
+	fm.allTypes[key] = flagType
+}
+
+func ValidateFlagEnums(flags *map[string]string, cmdEnums map[string][]string) error {
+	var builder strings.Builder
+	for key, value := range *flags {
+		if enumList, exists := cmdEnums[key]; exists {
+			valueUpper := strings.ToUpper(value)
+			found := false
+			for _, elem := range enumList {
+				if strings.ToUpper(elem) == valueUpper {
+					found = true
+					(*flags)[key] = valueUpper
+					break
+				}
+			}
+			if !found {
+				builder.WriteString("Error: flag \"")
+				builder.WriteString(key)
+				builder.WriteString("\": value \"")
+				builder.WriteString(value)
+				builder.WriteString("\" was not in the valid set (")
+				builder.WriteString(strings.Join(enumList, ", "))
+				builder.WriteString(")\n")
+			}
+		}
+	}
+	str := builder.String()
+	if str != "" {
+		return errors.New(str)
+	}
+	return nil
+}
+
+func ValidateEnumArray(content string, enumList []string) ([]string, error) {
+	var output []string
+	if content == "" {
+		return output, nil
+	}
+
+	var builder strings.Builder
+	input := strings.Split(content, ",")
+
+	for _, value := range input {
+		valueUpper := strings.ToUpper(value)
+		found := false
+		for _, elem := range enumList {
+			if strings.ToUpper(elem) == valueUpper {
+				if output == nil {
+					output = make([]string, 0)
+				}
+				output = append(output, valueUpper)
+				found = true
+				break
+			}
+		}
+		if !found {
+			builder.WriteString("Error: value \"")
+			builder.WriteString(value)
+			builder.WriteString("\" was not valid\n")
+		}
+	}
+	if builder.Len() > 0 {
+		builder.WriteString("Acceptable values: (")
+		builder.WriteString(strings.Join(enumList, ", "))
+		builder.WriteString(")")
+		return output, errors.New(builder.String())
+	}
+
+	return output, nil
+}
+
+func AddFlagsEnum(enumMap *map[string][]string, flagName string, newEnum []string) string {
+	if *enumMap == nil {
+		*enumMap = make(map[string][]string)
+	}
+	(*enumMap)[flagName] = newEnum
+
+	var builder strings.Builder
+	builder.WriteString("(")
+	builder.WriteString(strings.Join(newEnum, ", "))
+	builder.WriteString(")")
+	return builder.String()
+}

--- a/cmd/util_testing.go
+++ b/cmd/util_testing.go
@@ -1,0 +1,131 @@
+package cmd
+
+import (
+	"encoding/json"
+	"errors"
+	"fmt"
+	"os"
+	"testing"
+	"truenas/truenas-admin/core"
+
+	"github.com/spf13/cobra"
+)
+
+type UnitTestSession struct {
+	test *testing.T
+	expects []string
+	responses []string
+	tableExpected string
+	callIdx int
+	shouldIncCallIdx bool
+}
+
+func (s *UnitTestSession) Login() error { return nil }
+func (s *UnitTestSession) Close() error { return nil }
+
+func (s *UnitTestSession) CallRaw(method string, timeoutStr string, params interface{}) (json.RawMessage, error) {
+	if s.shouldIncCallIdx {
+		s.callIdx++
+	}
+	data, err := json.Marshal(params)
+	FailIf(s.test, err)
+	expect := s.expects[s.callIdx]
+	if string(data) != expect {
+		return nil, fmt.Errorf("\"%s\" != \"%s\"", string(data), expect)
+	}
+	response := []byte(s.responses[s.callIdx])
+	s.shouldIncCallIdx = true
+	return response, nil
+}
+
+func PrintTable(api core.Session, str string) {
+	if unit, isUnitTest := api.(*UnitTestSession); isUnitTest {
+		if unit.tableExpected != str {
+			unit.test.Error(errors.New("table:\n" + str + "did not match expected:\n" + unit.tableExpected))
+		}
+	} else {
+		os.Stdout.WriteString(str)
+	}
+}
+
+func SetupSimpleTest(t *testing.T, expect, response string) *UnitTestSession {
+	api := &UnitTestSession{}
+	//api.Login()
+	api.test = t
+	api.expects = []string{expect}
+	api.responses = []string{response}
+	return api
+}
+
+func DoSimpleTest(
+	t *testing.T,
+	cmd *cobra.Command,
+	commandFunc func(*cobra.Command,core.Session,[]string)error,
+	props map[string]interface{},
+	args []string,
+	expect string,
+) error {
+	response := "{}"
+	for key, value := range props {
+		SetAuxCobraFlag(cmd, key, value)
+	}
+	defer ResetAuxCobraFlags(cmd)
+	err := commandFunc(cmd, SetupSimpleTest(t, expect, response), args)
+	if err != nil {
+		errMsg := err.Error()
+		if errMsg != expect {
+			fmt.Println("\"" + errMsg + "\" != \"" + expect + "\"")
+			return err
+		}
+	}
+	return nil
+}
+
+func SetupMultiTest(t *testing.T, expectList, responseList []string, tableExpected string) *UnitTestSession {
+	if len(expectList) != len(responseList) || len(expectList) < 1 {
+		return nil
+	}
+	api := &UnitTestSession{}
+	//api.Login()
+	api.test = t
+	api.expects = expectList
+	api.responses = responseList
+	api.tableExpected = tableExpected
+	return api
+}
+
+func DoTest(
+	t *testing.T,
+	cmd *cobra.Command,
+	commandFunc func(*cobra.Command,core.Session,[]string)error,
+	props map[string]interface{},
+	args []string,
+	expectList []string,
+	responseList []string,
+	tableExpected string,
+) error {
+	for key, value := range props {
+		SetAuxCobraFlag(cmd, key, value)
+	}
+	defer ResetAuxCobraFlags(cmd)
+	api := SetupMultiTest(t, expectList, responseList, tableExpected)
+	if api == nil {
+		return errors.New("Failed to set up test correctly. Check expectList and responseList.")
+	}
+	err := commandFunc(cmd, api, args)
+	if err != nil {
+		errMsg := err.Error()
+		expectMsg := expectList[api.callIdx]
+		if expectMsg != errMsg {
+			fmt.Println("\"" + errMsg + "\" != \"" + expectMsg + "\"")
+			return err
+		}
+	}
+	return nil
+}
+
+func FailIf(t *testing.T, err error) {
+	if err != nil {
+		t.Error(err)
+	}
+}

--- a/cmd/version.go
+++ b/cmd/version.go
@@ -1,0 +1,33 @@
+package cmd
+
+import (
+	"fmt"
+
+	"github.com/spf13/cobra"
+)
+
+/*
+0.1.0 initial version
+0.1.1 added url, apikey and keyfile
+0.1.2 added `share nfs` functionality
+0.1.3 improved querying, removed --name and --id from `share nfs list`
+0.1.4 added `--update-shares` to `dataset rename`
+0.1.5 removed inspect command
+0.1.6 `share nfs delete“ now supports <id|dataset|path>
+0.1.7 `share nfs update now supports `--create`
+0.1.8 most methods now return non-zero on error
+0.2.0 renamed to `truenas-admin`, first published version
+*/
+const VERSION = "0.2.0"
+
+var versionCmd = &cobra.Command{
+	Use:   "version",
+	Short: "Print the version of this program",
+	Run: func(cmd *cobra.Command, args []string) {
+		fmt.Println(VERSION)
+	},
+}
+
+func init() {
+	rootCmd.AddCommand(versionCmd)
+}

--- a/core/mock_api.go
+++ b/core/mock_api.go
@@ -1,0 +1,629 @@
+package core
+
+import (
+	"encoding/json"
+	"errors"
+	"fmt"
+	"slices"
+	"strings"
+)
+
+type MockSession struct {
+	DatasetSource ReadAllWriteAll
+	closed bool
+}
+
+func (s *MockSession) Login() error {
+	s.closed = false
+	return nil
+}
+
+func (s *MockSession) Close() error {
+	s.closed = true
+	return nil
+}
+
+func (s *MockSession) CallRaw(method string, timeoutStr string, params interface{}) (json.RawMessage, error) {
+	if s.closed {
+		return nil, errors.New("API connection closed")
+	}
+
+	// se: I think this is a valid assertion, and should help catch logic issues.
+	_, ok := params.([]interface{})
+	if !ok {
+		return nil, errors.New("params for Call must be in the form of an array")
+	}
+
+	switch method {
+	case "pool.dataset.create":
+		return s.mockDatasetCreate(params)
+	case "zfs.dataset.create":
+		return s.mockDatasetCreate(params)
+	case "pool.dataset.update":
+		return s.mockDatasetUpdate(params)
+	case "zfs.dataset.update":
+		return s.mockDatasetUpdate(params)
+	case "pool.dataset.delete":
+		return s.mockDatasetDelete(params)
+	case "zfs.dataset.delete":
+		return s.mockDatasetDelete(params)
+	case "pool.dataset.query":
+		return s.mockDatasetQuery(params)
+	case "zfs.dataset.query":
+		return s.mockDatasetQuery(params)
+	case "zfs.dataset.rename":
+		return s.mockDatasetRename(params)
+	default:
+		return nil, errors.New("Unrecognised command " + method)
+	}
+}
+
+func getPoolNameFromDataset(datasetName string) string {
+	firstSlash := strings.Index(datasetName, "/")
+	var poolName string
+	if firstSlash > 0 && firstSlash < len(datasetName)-1 {
+		poolName = datasetName[0:firstSlash]
+	}
+	return poolName
+}
+
+type MockDataset struct {
+	name       string
+	properties map[string]string
+	userProps  map[string]string
+}
+
+func loadMockDatasets(source ReadAllWriteAll) map[string]MockDataset {
+	var datasets map[string]MockDataset
+	content, err := source.ReadAll()
+	if err != nil || len(content) == 0 {
+		return datasets
+	}
+
+	lines := strings.Split(string(content), "\n")
+	for _, l := range lines {
+		values := strings.Split(l, "\t")
+		if len(l) < 1 {
+			continue
+		}
+		d := MockDataset{}
+		d.name = values[0]
+		for j := 1; j < len(values)-1; j += 2 {
+			key := values[j]
+			value := values[j+1]
+			if strings.HasPrefix(key, "user:") {
+				if d.userProps == nil {
+					d.userProps = make(map[string]string)
+				}
+				d.userProps[key[5:]] = value
+			} else {
+				if d.properties == nil {
+					d.properties = make(map[string]string)
+				}
+				d.properties[key] = value
+			}
+		}
+		if datasets == nil {
+			datasets = make(map[string]MockDataset)
+		}
+		datasets[d.name] = d
+	}
+
+	return datasets
+}
+
+func saveMockDatasets(source ReadAllWriteAll, datasets *map[string]MockDataset) {
+	var output strings.Builder
+	idx := 0
+	for _, d := range *datasets {
+		output.WriteString(d.name)
+		for key, value := range d.properties {
+			output.WriteString("\t")
+			output.WriteString(key)
+			output.WriteString("\t")
+			output.WriteString(value)
+		}
+		for key, value := range d.userProps {
+			output.WriteString("\tuser:")
+			output.WriteString(key)
+			output.WriteString("\t")
+			output.WriteString(value)
+		}
+		output.WriteString("\n")
+		idx++
+	}
+
+	if idx > 0 {
+		_ = source.WriteAll([]byte(output.String()))
+	}
+}
+
+type typeCreateUpdateDatasetParams struct {
+	datasetName string
+	comments    string
+	properties  map[string]string
+	userProps   map[string]string
+}
+
+func getParamArray(params interface{}, minArgs int) ([]interface{}, error) {
+	paramArray, ok := params.([]interface{})
+
+	if !ok {
+		return nil, errors.New("params must be supplied as an array")
+	}
+
+	if len(paramArray) < minArgs {
+		formatted := fmt.Sprintf("params array must contain least %d entries", minArgs)
+		return nil, errors.New(formatted)
+	}
+
+	return paramArray, nil
+}
+
+func getCreateUpdateDatasetParams(params interface{}) (typeCreateUpdateDatasetParams, error) {
+	cdp := typeCreateUpdateDatasetParams{}
+
+	paramArray, err := getParamArray(params, 1)
+	if err != nil {
+		return cdp, err
+	}
+
+	paramsMap, ok := paramArray[0].(map[string]interface{})
+	if !ok {
+		return cdp, errors.New("parameters for 'create/update' must be in the form of a map")
+	}
+
+	if value, ok := paramsMap["name"]; ok {
+		if cdp.datasetName, ok = value.(string); !ok {
+			return cdp, errors.New("name was not a string")
+		}
+		if strings.Index(cdp.datasetName, "/") <= 0 {
+			return cdp, errors.New("dataset name must contain its pool name before a slash, eg. puddle/example")
+		}
+	}
+	if value, ok := paramsMap["comments"]; ok {
+		if cdp.comments, ok = value.(string); !ok {
+			return cdp, errors.New("comments was not a string")
+		}
+	}
+	if value, ok := paramsMap["properties"]; ok {
+		var inMap map[string]interface{}
+		if inMap, ok = value.(map[string]interface{}); !ok {
+			return cdp, errors.New("properties was not a map/dictionary")
+		}
+		for key, pv := range inMap {
+			pvStr, ok := pv.(string)
+			if ok {
+				pvStr = "\"" + pvStr + "\""
+			} else {
+				pvStr = fmt.Sprintf("%v", pv)
+			}
+			if cdp.properties == nil {
+				cdp.properties = make(map[string]string)
+			}
+			cdp.properties[key] = pvStr
+		}
+	}
+	if value, ok := paramsMap["user_properties"]; ok {
+		var inMapList []interface{}
+		if inMapList, ok = value.([]interface{}); !ok {
+			return cdp, errors.New("user properties was not an array of map/dictionary")
+		}
+		for _, elem := range inMapList {
+			inMap, ok := elem.(map[string]interface{})
+			if !ok {
+				return cdp, errors.New("user properties was not entirely an array of map/dictionary")
+			}
+
+			var uKeyStr string
+			uKey, keyExists := inMap["key"]
+			if !keyExists {
+				return cdp, errors.New("user property did not contain a 'key'")
+			}
+			if uKeyStr, ok = uKey.(string); !ok {
+				return cdp, errors.New("user property key was not a string")
+			}
+
+			var uValueStr string
+			uValue, valueExists := inMap["value"]
+			if !valueExists {
+				return cdp, errors.New("user property '" + uKeyStr + "' did not contain a value")
+			}
+			if uValueStr, ok = uValue.(string); !ok {
+				uValueStr = "\"" + uValueStr + "\""
+			} else {
+				uValueStr = fmt.Sprintf("%v", uValue)
+			}
+
+			if cdp.userProps == nil {
+				cdp.userProps = make(map[string]string)
+			}
+			cdp.userProps[uKeyStr] = uValueStr
+		}
+	}
+	return cdp, nil
+}
+
+func editDatasetProperties(cdp *typeCreateUpdateDatasetParams, dataset *MockDataset) ([]string, []string) {
+	var propertyKeys []string
+	nProps := len(cdp.properties)
+	if nProps > 0 {
+		propertyKeys = make([]string, 0, nProps)
+		if dataset.properties == nil {
+			dataset.properties = make(map[string]string)
+		}
+		for key, value := range cdp.properties {
+			dataset.properties[key] = value
+			propertyKeys = append(propertyKeys, key)
+		}
+		slices.Sort(propertyKeys)
+	}
+
+	var userPropKeys []string
+	nUserProps := len(cdp.userProps)
+	if nProps > 0 {
+		userPropKeys = make([]string, 0, nUserProps)
+		if dataset.userProps == nil {
+			dataset.userProps = make(map[string]string)
+		}
+		for key, value := range cdp.userProps {
+			dataset.userProps[key] = value
+			userPropKeys = append(userPropKeys, key)
+		}
+		slices.Sort(userPropKeys)
+	}
+
+	return propertyKeys, userPropKeys
+}
+
+func (s *MockSession) mockDatasetCreate(params interface{}) (json.RawMessage, error) {
+	cdp, err := getCreateUpdateDatasetParams(params)
+	if err != nil {
+		return nil, err
+	}
+
+	if cdp.datasetName == "" {
+		return nil, errors.New("No dataset name was provided")
+	}
+
+	shouldCreateParents := false
+	if parentsValue, ok := cdp.properties["create_ancestors"]; ok {
+		shouldCreateParents = parentsValue == "true"
+		delete(cdp.properties, "create_ancestors")
+	}
+
+	datasets := loadMockDatasets(s.DatasetSource)
+
+	if datasets != nil {
+		if _, exists := datasets[cdp.datasetName]; exists {
+			return nil, errors.New("Dataset already exists")
+		}
+	} else {
+		datasets = make(map[string]MockDataset)
+	}
+
+	newDataset := MockDataset{}
+	newDataset.properties = make(map[string]string)
+	newDataset.name = cdp.datasetName
+
+	parts := strings.Split(cdp.datasetName, "/")
+	for i := len(parts) - 2; i >= 1; i-- {
+		// wasteful but easy
+		parentName := strings.Join(parts[0:i+1], "/")
+		if _, exists := datasets[parentName]; !exists {
+			if shouldCreateParents {
+				parent := MockDataset{}
+				parent.name = parentName
+				datasets[parentName] = parent
+			} else {
+				return nil, errors.New("Parent dataset \"" + parentName + "\" does not exist")
+			}
+		}
+	}
+
+	propertyKeys, userPropKeys := editDatasetProperties(&cdp, &newDataset)
+
+	datasets[cdp.datasetName] = newDataset
+	saveMockDatasets(s.DatasetSource, &datasets)
+
+	var output strings.Builder
+	writeDatasetInfo(&output, &newDataset, propertyKeys, userPropKeys)
+	return []byte(output.String()), nil
+}
+
+func (s *MockSession) mockDatasetUpdate(params interface{}) (json.RawMessage, error) {
+	udp, err := getCreateUpdateDatasetParams(params)
+	if err != nil {
+		return nil, err
+	}
+
+	if udp.datasetName == "" {
+		return nil, errors.New("No dataset name was provided")
+	}
+
+	shouldUpdateParents := false
+	if parentsValue, ok := udp.properties["create_ancestors"]; ok {
+		shouldUpdateParents = parentsValue == "true"
+		delete(udp.properties, "create_ancestors")
+	}
+	shouldUpdateParents = shouldUpdateParents
+
+	datasets := loadMockDatasets(s.DatasetSource)
+	if datasets == nil {
+		return nil, errors.New("dataset does not exist")
+	}
+	dataset, exists := datasets[udp.datasetName]
+	if !exists {
+		return nil, errors.New("dataset does not exist")
+	}
+
+	propertyKeys, userPropKeys := editDatasetProperties(&udp, &dataset)
+	datasets[udp.datasetName] = dataset
+	saveMockDatasets(s.DatasetSource, &datasets)
+
+	var output strings.Builder
+	writeDatasetInfo(&output, &dataset, propertyKeys, userPropKeys)
+	return []byte(output.String()), nil
+}
+
+func (s *MockSession) mockDatasetRename(params interface{}) (json.RawMessage, error) {
+	paramsList, err := getParamArray(params, 2)
+	if err != nil {
+		return nil, err
+	}
+
+	var oldName string
+	var newName string
+
+	if value, ok := paramsList[0].(string); ok {
+		oldName = value
+	} else {
+		return nil, errors.New("Dataset name (first param) was not a string")
+	}
+
+	if value, ok := paramsList[1].(map[string]interface{}); ok {
+		if inner, ok := value["new_name"]; ok {
+			if newName, ok = inner.(string); !ok {
+				return nil, errors.New("New dataset name (second param) was not a string")
+			}
+		}
+	} else if value, ok := paramsList[1].(string); ok {
+		newName = value
+	}
+
+	if oldName == "" {
+		return nil, errors.New("Dataset name (first param) was empty")
+	}
+	if newName == "" {
+		return nil, errors.New("New dataset name (second param) was empty")
+	}
+	if newName == oldName {
+		return nil, errors.New("New dataset name (second param) matches old dataset name (first param)")
+	}
+
+	datasets := loadMockDatasets(s.DatasetSource)
+	if datasets == nil {
+		return nil, errors.New("dataset does not exist")
+	}
+	dataset, exists := datasets[oldName]
+	if !exists {
+		return nil, errors.New("dataset does not exist")
+	}
+
+	delete(datasets, oldName)
+	dataset.name = newName
+	datasets[newName] = dataset
+
+	saveMockDatasets(s.DatasetSource, &datasets)
+
+	return []byte("True"), nil
+}
+
+func (s *MockSession) mockDatasetDelete(params interface{}) (json.RawMessage, error) {
+	paramArray, err := getParamArray(params, 1)
+	if err != nil {
+		return nil, err
+	}
+
+	datasetName, ok := paramArray[0].(string)
+	if !ok {
+		return nil, errors.New("dataset delete requires a string, representing the name of the dataset to delete")
+	}
+
+	datasets := loadMockDatasets(s.DatasetSource)
+
+	if datasets == nil {
+		return nil, errors.New("dataset does not exist")
+	}
+	if _, exists := datasets[datasetName]; !exists {
+		return nil, errors.New("dataset does not exist")
+	}
+
+	delete(datasets, datasetName)
+	saveMockDatasets(s.DatasetSource, &datasets)
+
+	return []byte("True"), nil
+}
+
+type typeQueryDatasetParams struct {
+	datasetName       string
+	properties        []string
+	isFlat            bool
+	withChildren      bool
+	withUser          bool
+	shouldGetAllProps bool
+}
+
+func getQueryDatasetParams(paramsList []interface{}) (typeQueryDatasetParams, error) {
+	qdp := typeQueryDatasetParams{}
+	cur := 0
+	if cur >= len(paramsList) {
+		return qdp, nil
+	}
+	if filterParamOuter, ok := paramsList[cur].([]interface{}); ok {
+		// len == 0 is valid, and implies ALL datasets
+		if len(filterParamOuter) > 0 {
+			if filterParam, ok := filterParamOuter[0].([]interface{}); ok {
+				if len(filterParam) >= 3 {
+					if idString, ok := filterParam[2].(string); ok {
+						qdp.datasetName = idString
+					} else if idArray, ok := filterParam[2].([]interface{}); ok {
+						if idString, ok := idArray[0].(string); ok {
+							qdp.datasetName = idString
+						}
+					}
+				}
+				if qdp.datasetName == "" {
+					return qdp, errors.New("Could not find dataset name in name filter")
+				}
+				cur++
+			}
+		} else {
+			cur++
+		}
+	}
+	if cur >= len(paramsList) {
+		return qdp, nil
+	}
+	if propsParam, ok := paramsList[cur].(map[string]interface{}); ok {
+		var extraMap map[string]interface{}
+		if extra, ok := propsParam["extra"]; ok {
+			extraMap, ok = extra.(map[string]interface{})
+		}
+		if extraMap == nil {
+			return qdp, errors.New("Could not find dataset options in the parameters")
+		}
+		if value, ok := extraMap["flat"]; ok {
+			qdp.isFlat, ok = value.(bool)
+		}
+		if value, ok := extraMap["retrieve_children"]; ok {
+			qdp.withChildren, ok = value.(bool)
+		}
+		if value, ok := extraMap["user_properties"]; ok {
+			qdp.withUser, ok = value.(bool)
+		}
+		if value, ok := extraMap["properties"]; ok {
+			if props, ok := value.([]interface{}); ok {
+				for _, elem := range props {
+					str := ""
+					if str, ok = elem.(string); !ok {
+						str = fmt.Sprint(elem)
+					}
+					qdp.properties = append(qdp.properties, str)
+				}
+			} else if value == nil {
+				qdp.shouldGetAllProps = true
+			}
+		}
+	}
+	return qdp, nil
+}
+
+func writeDatasetInfo(output *strings.Builder, dataset *MockDataset, propertiesKeys []string, userPropsKeys []string) {
+	poolName := getPoolNameFromDataset(dataset.name)
+	output.WriteString("{ \"id\":\"")
+	output.WriteString(dataset.name)
+	output.WriteString("\", \"type\":\"FILESYSTEM\", \"name\":\"")
+	output.WriteString(dataset.name)
+	output.WriteString("\", \"pool\":\"")
+	output.WriteString(poolName)
+	output.WriteString("\", ")
+	if propertiesKeys != nil {
+		output.WriteString("\"properties\":{")
+		isFirstProp := true
+		for _, prop := range propertiesKeys {
+			value, exists := dataset.properties[prop]
+			if !exists {
+				continue
+			}
+			if !isFirstProp {
+				output.WriteString(",\n")
+			}
+			output.WriteString("\"")
+			output.WriteString(prop)
+			output.WriteString("\":{\"value\":")
+			output.WriteString(value)
+			output.WriteString(", \"rawvalue\":")
+			output.WriteString(value)
+			output.WriteString(", \"source\":\"LOCAL\", \"parsed\":")
+			output.WriteString(value)
+			output.WriteString("}")
+			isFirstProp = false
+		}
+		output.WriteString("},\n")
+	}
+	output.WriteString("\"comments\":{\"value\":\"\", \"rawvalue\":\"\", \"source\":\"LOCAL\", \"parsed\":\"\"}, \"user_properties\":{")
+	if userPropsKeys != nil {
+		isFirstProp := true
+		for _, prop := range userPropsKeys {
+			value, exists := dataset.userProps[prop]
+			if !exists {
+				continue
+			}
+			if !isFirstProp {
+				output.WriteString(",\n")
+			}
+			output.WriteString("\"")
+			output.WriteString(prop)
+			output.WriteString("\":{\"value\":")
+			output.WriteString(value)
+			output.WriteString(", \"rawvalue\":\"")
+			output.WriteString(value)
+			output.WriteString(", \"source\":\"LOCAL\", \"parsed\":")
+			output.WriteString(value)
+			output.WriteString("}")
+			isFirstProp = false
+		}
+	}
+	output.WriteString("} }")
+}
+
+func (s *MockSession) mockDatasetQuery(params interface{}) (json.RawMessage, error) {
+	qdp := typeQueryDatasetParams{}
+	if paramsList, ok := params.([]interface{}); ok {
+		var err error
+		qdp, err = getQueryDatasetParams(paramsList)
+		if err != nil {
+			return nil, err
+		}
+	}
+
+	datasets := loadMockDatasets(s.DatasetSource)
+
+	var output strings.Builder
+	output.WriteString("{\"jsonrpc\":\"2.0\", \"result\":[")
+
+	if datasets != nil {
+		if qdp.datasetName != "" {
+			if dataset, exists := datasets[qdp.datasetName]; exists {
+				var properties []string
+				if qdp.shouldGetAllProps {
+					properties = GetKeysSorted(dataset.properties)
+				} else {
+					properties = qdp.properties
+				}
+				writeDatasetInfo(&output, &dataset, properties, nil)
+			}
+		} else {
+			datasetNames := GetKeysSorted(datasets)
+			for idx, name := range datasetNames {
+				dataset := datasets[name]
+				if idx > 0 {
+					output.WriteString(", ")
+				}
+				var properties []string
+				if qdp.shouldGetAllProps {
+					properties = GetKeysSorted(dataset.properties)
+				} else {
+					properties = qdp.properties
+				}
+				writeDatasetInfo(&output, &dataset, properties, nil)
+				idx++
+			}
+		}
+	}
+
+	output.WriteString("], \"id\":2}")
+	outStr := output.String()
+	return []byte(outStr), nil
+}

--- a/core/print_data.go
+++ b/core/print_data.go
@@ -1,0 +1,215 @@
+package core;
+
+import (
+	"encoding/json"
+	"errors"
+	"fmt"
+	"strings"
+)
+
+func BuildTableData(format string, jsonName string, columnsList []string, data []map[string]interface{}) (string, error) {
+	var table strings.Builder
+	var err error
+	f := strings.ToLower(format)
+
+	switch f {
+	case "compact":
+		WriteListCsv(&table, data, columnsList, false)
+	case "csv":
+		WriteListCsv(&table, data, columnsList, true)
+	case "json":
+		err = WriteJson(&table, data, columnsList, jsonName)
+	case "table":
+		WriteListTable(&table, data, columnsList, true)
+	default:
+		return "", fmt.Errorf("Unrecognised table format \"%s\"", f)
+	}
+
+	return table.String(), err
+}
+
+func WriteListCsv(builder *strings.Builder, propsArray []map[string]interface{}, columnsList []string, useHeaders bool) {
+	if len(propsArray) == 0 || len(columnsList) == 0 {
+		return
+	}
+
+	isFirstCol := true
+	if useHeaders {
+		for _, c := range(columnsList) {
+			if !isFirstCol {
+				builder.WriteString("\t")
+			}
+			builder.WriteString(c)
+			isFirstCol = false
+		}
+		builder.WriteString("\n")
+	}
+	var line strings.Builder
+	for i := 0; i < len(propsArray); i++ {
+		line.Reset()
+		isFirstCol = true
+		hits := 0
+		for _, c := range(columnsList) {
+			if !isFirstCol {
+				line.WriteString("\t")
+			}
+			if value, ok := propsArray[i][c]; ok {
+				if valueStr, ok := value.(string); ok {
+					line.WriteString(valueStr)
+				} else {
+					line.WriteString(fmt.Sprint(value))
+				}
+				hits++
+			} else {
+				line.WriteString("-")
+			}
+			isFirstCol = false
+		}
+		if hits > 0 {
+			builder.WriteString(line.String())
+			builder.WriteString("\n")
+		}
+	}
+}
+
+func WriteJson(builder *strings.Builder, propsArray []map[string]interface{}, columnsList []string, jsonName string) error {
+	obj := make(map[string]interface{})
+	for _, elem := range propsArray {
+		id, ok := elem["id"]
+		if !ok {
+			id, ok = elem["name"]
+			if !ok {
+				return errors.New("Could not find id or name in json table data")
+			}
+		}
+
+		record := make(map[string]interface{})
+		for _, c := range columnsList {
+			if value, exists := elem[c]; exists {
+				record[c] = value
+			}
+		}
+
+		idStr := fmt.Sprint(id)
+		obj[idStr] = record
+	}
+
+	jsonObj := make(map[string]interface{})
+	jsonObj[jsonName] = obj
+	data, err := json.Marshal(jsonObj)
+	if err != nil {
+		return err
+	}
+
+	builder.WriteString(string(data))
+	builder.WriteString("\n")
+	return nil
+}
+
+func WriteListTable(builder *strings.Builder, propsArray []map[string]interface{}, columnsList []string, useHeaders bool) {
+	if len(propsArray) == 0 || len(columnsList) == 0 {
+		return
+	}
+
+	headerInc := 0
+	if useHeaders {
+		headerInc = 1
+	}
+
+	allStrings := make([]string, 0, len(columnsList) * (headerInc + len(propsArray)))
+	if useHeaders {
+		for i := 0; i < len(columnsList); i++ {
+			allStrings = append(allStrings, columnsList[i])
+		}
+	}
+	for i := 0; i < len(propsArray); i++ {
+		for _, c := range(columnsList) {
+			var str string
+			if value, ok := propsArray[i][c]; ok {
+				if valueStr, ok := value.(string); ok {
+					str = valueStr
+				} else {
+					str = fmt.Sprint(value)
+				}
+			}
+			allStrings = append(allStrings, str)
+		}
+	}
+
+	writeTable(builder, allStrings, headerInc + len(propsArray), len(columnsList), useHeaders)
+}
+
+func writeTable(builder *strings.Builder, allStrings []string, nRows int, nCols int, useHeaders bool) {
+	columnWidths := make([]int, nCols, nCols)
+	for i := 0; i < nRows; i++ {
+		for j := 0; j < nCols; j++ {
+			size := len(allStrings[i*nCols+j])
+			if size > columnWidths[j] {
+				columnWidths[j] = size
+			}
+		}
+	}
+
+	widestCol := columnWidths[0]
+	for i := 1; i < nCols; i++ {
+		if columnWidths[i] > widestCol {
+			widestCol = columnWidths[i]
+		}
+	}
+
+	bufSpaces  := make([]byte, widestCol+2, widestCol+2)
+	bufHyphens := make([]byte, widestCol+2, widestCol+2)
+	for i := 0; i < widestCol+2; i++ {
+		bufSpaces[i]  = 0x20; // space
+		bufHyphens[i] = 0x2d; // -
+	}
+
+	var line strings.Builder
+	for i := 0; i < nRows; i++ {
+		line.Reset()
+		hits := 0
+		isFirstCol := true
+		for j := 0; j < nCols; j++ {
+			idx := i * nCols + j
+			sp := columnWidths[j] - len(allStrings[idx])
+
+			if !isFirstCol {
+				line.WriteString("|")
+			}
+			line.WriteString(" ")
+			if useHeaders && i == 0 {
+				line.Write(bufSpaces[0:sp/2])
+				line.WriteString(allStrings[idx])
+				line.Write(bufSpaces[0:sp/2+(sp%2)])
+				hits++
+			} else {
+				line.WriteString(allStrings[idx])
+				line.Write(bufSpaces[0:sp])
+				if allStrings[idx] != "" {
+					hits++
+				}
+			}
+			line.WriteString(" ")
+
+			isFirstCol = false
+		}
+		if useHeaders && i == 0 {
+			line.WriteString("\n")
+
+			isFirstCol = true
+			for i := 0; i < nCols; i++ {
+				if !isFirstCol {
+					line.WriteString("+")
+				}
+				line.Write(bufHyphens[0:columnWidths[i]+2])
+				isFirstCol = false
+			}
+			// ensures the column headers and separating line are not culled
+			hits++
+		}
+		if hits > 0 {
+			builder.WriteString(line.String())
+			builder.WriteString("\n")
+		}
+	}
+}

--- a/core/real_api.go
+++ b/core/real_api.go
@@ -1,0 +1,51 @@
+package core
+
+import (
+	"errors"
+	"strings"
+	"encoding/json"
+	"truenas/truenas-admin/truenas_api"
+)
+
+type RealSession struct {
+	HostUrl string
+	ApiKey string
+	client *truenas_api.Client
+}
+
+func (s *RealSession) Login() error {
+	if s.client != nil {
+		_ = s.Close()
+	}
+
+	if s.HostUrl == "" || s.ApiKey == "" {
+		return errors.New("--url and --api-key were not provided")
+	}
+
+	client, err := truenas_api.NewClient(s.HostUrl, strings.HasPrefix(s.HostUrl, "wss://"))
+	if err != nil {
+		return errors.New("Failed to create client: " + err.Error())
+	}
+
+	err = client.Login("", "", s.ApiKey)
+	if err != nil {
+		client.Close()
+		return errors.New("Client login failed: " + err.Error())
+	}
+
+	s.client = client
+	return nil
+}
+
+func (s *RealSession) CallRaw(method string, timeoutStr string, params interface{}) (json.RawMessage, error) {
+	return s.client.Call(method, timeoutStr, params)
+}
+
+func (s *RealSession) Close() error {
+	var err error
+	if s.client != nil {
+		err = s.client.Close()
+		s.client = nil
+	}
+	return err
+}

--- a/core/session.go
+++ b/core/session.go
@@ -1,0 +1,23 @@
+package core
+
+import (
+	"encoding/json"
+	"errors"
+)
+
+type Session interface {
+	Login() error
+	CallRaw(method string, timeoutStr string, params interface{}) (json.RawMessage, error)
+	Close() error
+}
+
+func ApiCall(s Session, method string, timeoutStr string, params interface{}) (json.RawMessage, error) {
+	out, err := s.CallRaw(method, timeoutStr, params)
+	if err != nil {
+		return out, err
+	}
+	if errMsg := ExtractApiError(out); errMsg != "" {
+		return out, errors.New(errMsg)
+	}
+	return out, nil
+}

--- a/core/util.go
+++ b/core/util.go
@@ -1,0 +1,165 @@
+package core
+
+import (
+	"encoding/json"
+	"fmt"
+	"os"
+	"strconv"
+	"strings"
+	"slices"
+)
+
+func IdentifyObject(obj string) (string, string) {
+	if obj == "" {
+		return "", ""
+	} else if _, errNotNumber := strconv.Atoi(obj); errNotNumber == nil {
+		return "id", obj
+	} else if obj[0] == '/' {
+		return "share", obj
+	} else if obj[0] == '@' {
+		return "snapshot_only", obj[1:]
+	} else if pos := strings.Index(obj, "@"); pos >= 1 {
+		if pos == len(obj)-1 {
+			return "error", obj
+		}
+		return "snapshot", obj
+	} else if pos := strings.LastIndex(obj, "/"); pos >= 1 {
+		if pos == len(obj)-1 {
+			return IdentifyObject(obj[0:len(obj)-1])
+		}
+		return "dataset", obj
+	}
+	return "pool", obj
+}
+
+func GetKeysSorted[T any](dict map[string]T) []string {
+	var keys []string
+	size := len(dict)
+	if size > 0 {
+		keys = make([]string, 0, size)
+		for k, _ := range dict {
+			keys = append(keys, k)
+		}
+		slices.Sort(keys)
+	}
+	return keys
+}
+
+func ExtractJsonArrayOfMaps(obj map[string]interface{}, key string) ([]map[string]interface{}, string) {
+	if value, ok := obj[key]; ok {
+		if array, ok := value.([]interface{}); ok {
+			if len(array) == 0 {
+				return nil, ""
+			}
+			list := make([]map[string]interface{}, 0)
+			for i := 0; i < len(array); i++ {
+				if elem, ok := array[i].(map[string]interface{}); ok {
+					list = append(list, elem)
+				} else {
+					return nil, "contained a non-object entry"
+				}
+			}
+			return list, ""
+		}
+		return nil, "was not an array"
+	}
+	return nil, "did not contain a list"
+}
+
+func IsValueTrue(dict map[string]string, key string) bool {
+	if valueStr, exists := dict[key]; exists {
+		return valueStr == "true"
+	}
+	return false
+}
+
+func ExtractApiError(data json.RawMessage) string {
+	if len(data) == 0 {
+		return ""
+	}
+
+	var response interface{}
+	if err := json.Unmarshal(data, &response); err != nil {
+		return "\n" + err.Error()
+	}
+
+	responseMap, ok := response.(map[string]interface{})
+	if !ok {
+		return ""
+	}
+
+	errorValue, exists := responseMap["error"]
+	if !exists {
+		return ""
+	}
+
+	var codeStr string
+	var messageStr string
+	var reasonStr string
+
+	if errorObj, ok := errorValue.(map[string]interface{}); ok {
+		if codeValue, exists := errorObj["code"]; exists {
+			codeStr = fmt.Sprint(codeValue)
+		}
+		if messageValue, exists := errorObj["message"]; exists {
+			messageStr = fmt.Sprint(messageValue)
+		}
+		if dataValue, exists := errorObj["data"]; exists {
+			if dataObj, ok := dataValue.(map[string]interface{}); ok {
+				if reasonValue, exists := dataObj["reason"]; exists {
+					reasonStr = fmt.Sprint(reasonValue)
+				}
+			}
+		}
+	}
+
+	var builder strings.Builder
+	builder.WriteString("\nError ")
+	if codeStr != "" {
+		builder.WriteString(codeStr)
+		builder.WriteString("\n")
+	}
+	if messageStr != "" {
+		builder.WriteString(messageStr)
+		builder.WriteString("\n")
+	}
+	if reasonStr != "" {
+		builder.WriteString(reasonStr)
+	}
+
+	return builder.String()
+}
+
+type ReadAllWriteAll interface {
+	ReadAll() ([]byte, error)
+	WriteAll([]byte) error
+}
+
+type FileRawa struct {
+	FileName string
+}
+
+type MemoryRawa struct {
+	Current []byte
+}
+
+func (rw *FileRawa) ReadAll() ([]byte, error) {
+	return os.ReadFile(rw.FileName)
+}
+func (rw *FileRawa) WriteAll(content []byte) error {
+	return os.WriteFile(rw.FileName, content, 0666)
+}
+
+func (rw *MemoryRawa) ReadAll() ([]byte, error) {
+	var buf []byte
+	size := len(rw.Current)
+	if size > 0 {
+		buf = make([]byte, size)
+		copy(buf, rw.Current)
+	}
+	return buf, nil
+}
+func (rw *MemoryRawa) WriteAll(content []byte) error {
+	rw.Current = content
+	return nil
+}

--- a/go.mod
+++ b/go.mod
@@ -1,0 +1,10 @@
+module truenas/truenas-admin
+
+go 1.23.3
+
+require (
+	github.com/gorilla/websocket v1.5.3 // indirect
+	github.com/inconshreveable/mousetrap v1.1.0 // indirect
+	github.com/spf13/cobra v1.8.1 // indirect
+	github.com/spf13/pflag v1.0.5 // indirect
+)

--- a/go.sum
+++ b/go.sum
@@ -1,0 +1,12 @@
+github.com/cpuguy83/go-md2man/v2 v2.0.4/go.mod h1:tgQtvFlXSQOSOSIRvRPT7W67SCa46tRHOmNcaadrF8o=
+github.com/gorilla/websocket v1.5.3 h1:saDtZ6Pbx/0u+bgYQ3q96pZgCzfhKXGPqt7kZ72aNNg=
+github.com/gorilla/websocket v1.5.3/go.mod h1:YR8l580nyteQvAITg2hZ9XVh4b55+EU/adAjf1fMHhE=
+github.com/inconshreveable/mousetrap v1.1.0 h1:wN+x4NVGpMsO7ErUn/mUI3vEoE6Jt13X2s0bqwp9tc8=
+github.com/inconshreveable/mousetrap v1.1.0/go.mod h1:vpF70FUmC8bwa3OWnCshd2FqLfsEA9PFc4w1p2J65bw=
+github.com/russross/blackfriday/v2 v2.1.0/go.mod h1:+Rmxgy9KzJVeS9/2gXHxylqXiyQDYRxCVz55jmeOWTM=
+github.com/spf13/cobra v1.8.1 h1:e5/vxKd/rZsfSJMUX1agtjeTDf+qv1/JdBF8gg5k9ZM=
+github.com/spf13/cobra v1.8.1/go.mod h1:wHxEcudfqmLYa8iTfL+OuZPbBZkmvliBWKIezN3kD9Y=
+github.com/spf13/pflag v1.0.5 h1:iy+VFUOCP1a+8yFto/drg2CJ5u0yRoB7fZw3DKv/JXA=
+github.com/spf13/pflag v1.0.5/go.mod h1:McXfInJRrz4CZXVZOBLb0bTZqETkiAhM9Iw0y3An2Bg=
+gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=
+gopkg.in/yaml.v3 v3.0.1/go.mod h1:K4uyk7z7BCEPqu6E+C64Yfv1cQ7kz7rIZviUmN+EgEM=

--- a/main.go
+++ b/main.go
@@ -1,0 +1,7 @@
+package main
+
+import "truenas/truenas-admin/cmd"
+
+func main() {
+	cmd.Execute()
+}

--- a/truenas_api/truenas_api.go
+++ b/truenas_api/truenas_api.go
@@ -1,0 +1,392 @@
+package truenas_api
+
+import (
+	"crypto/tls"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"net/url"
+	"os"
+	"sync"
+	"time"
+
+	"github.com/gorilla/websocket"
+)
+
+// Client encapsulates the connection to the WebSocket server.
+type Client struct {
+	url        string                       // WebSocket server URL
+	conn       *websocket.Conn              // WebSocket connection instance
+	mu         sync.Mutex                   // Mutex for ensuring thread-safety
+	isClosed   bool                         // Indicates if the connection is closed
+	callID     int                          // Unique ID for tracking each call
+	pending    map[int]chan json.RawMessage // Stores pending calls, maps call IDs to response channels
+	notifyChan chan os.Signal               // For handling notifications (e.g., OS signals)
+	closeChan  chan struct{}                // Channel to signal when the connection should be closed
+	jobs       *Jobs                        // Jobs manager to track long-running jobs
+}
+
+// Job represents a long-running job in TrueNAS.
+type Job struct {
+	ID         int64                                             // Job ID
+	Method     string                                            // Method associated with the job
+	State      string                                            // Current state of the job (e.g., "PENDING", "SUCCESS")
+	Result     interface{}                                       // Result of the job once it finishes
+	Progress   float64                                           // Progress of the job (0.0 to 100.0)
+	Finished   bool                                              // Indicates if the job is finished
+	ProgressCh chan float64                                      // Channel to report progress updates
+	DoneCh     chan string                                       // Channel to signal when the job is done
+	Callback   func(progress float64, state string, desc string) // Callback function to report progress and state
+}
+
+// Jobs manages long-running tasks.
+type Jobs struct {
+	client      *Client        // Reference to the WebSocket client
+	jobs        map[int64]*Job // Maps job IDs to their corresponding job objects
+	ownedJobIDs map[int64]bool // Stores the job IDs that were started by this client
+	mu          sync.Mutex
+}
+
+// AddOwnedJob adds a job ID to the list of jobs started by this client.
+func (j *Jobs) AddOwnedJob(jobID int64) {
+	j.mu.Lock()
+	defer j.mu.Unlock()
+	j.ownedJobIDs[jobID] = true // Mark this job as "owned" by the client
+}
+
+// IsOwnedJob checks if a given job ID was started by this client.
+func (j *Jobs) IsOwnedJob(jobID int64) bool {
+	j.mu.Lock()
+	defer j.mu.Unlock()
+	_, exists := j.ownedJobIDs[jobID] // Check if the job ID exists in ownedJobIDs
+	return exists
+}
+
+// NewJobs creates a new Jobs manager.
+func NewJobs(client *Client) *Jobs {
+	return &Jobs{
+		client:      client,
+		jobs:        make(map[int64]*Job),
+		ownedJobIDs: make(map[int64]bool),
+	}
+}
+
+// AddJob adds a new job to the Jobs manager.
+func (j *Jobs) AddJob(jobID int64, method string) *Job {
+	j.mu.Lock()
+	defer j.mu.Unlock()
+	job := &Job{
+		ID:         jobID,
+		Method:     method,
+		State:      "PENDING",
+		ProgressCh: make(chan float64),
+		DoneCh:     make(chan string),
+	}
+	j.jobs[jobID] = job // Add job to jobs map
+	return job
+}
+
+// GetJob retrieves a job by its ID.
+func (j *Jobs) GetJob(jobID int64) (*Job, bool) {
+	j.mu.Lock()
+	defer j.mu.Unlock()
+	job, exists := j.jobs[jobID] // Retrieve the job by ID
+	return job, exists
+}
+
+// RemoveJob removes a completed job from the Jobs manager.
+func (j *Jobs) RemoveJob(jobID int64) {
+	j.mu.Lock()
+	defer j.mu.Unlock()
+	delete(j.jobs, jobID) // Remove job from jobs map
+}
+
+// UpdateJobState updates the state of a long-running job.
+func (j *Jobs) UpdateJobState(jobID int64, state string, progress float64, result interface{}, err string) {
+	j.mu.Lock()
+	defer j.mu.Unlock()
+	job, exists := j.jobs[jobID]
+	if !exists {
+		return // If the job doesn't exist, return
+	}
+	job.State = state
+	job.Progress = progress
+	if state == "SUCCESS" || state == "FAILED" {
+		job.Finished = true
+		job.Result = result
+		job.DoneCh <- err     // Send error (if any) to the done channel
+		close(job.ProgressCh) // Close progress channel after job completion
+		close(job.DoneCh)     // Close done channel after job completion
+	}
+}
+
+func (c *Client) SubscribeToJobs() error {
+	params := []interface{}{"core.get_jobs"} // Core function to subscribe to job updates
+
+	// Make the subscription call via WebSocket
+	res, err := c.Call("core.subscribe", "10s", params)
+	if err != nil {
+		return err
+	}
+
+	// Parse subscription result
+	var response map[string]interface{}
+	if err := json.Unmarshal(res, &response); err != nil {
+		return fmt.Errorf("failed to parse subscription response: %w", err)
+	}
+
+	return nil
+}
+
+// NewClient creates a new WebSocket client connection.
+func NewClient(serverURL string, verifySSL bool) (*Client, error) {
+	u, err := url.Parse(serverURL)
+	if err != nil {
+		return nil, fmt.Errorf("invalid URL: %w", err)
+	}
+
+	// Configure WebSocket connection options
+	dialer := websocket.DefaultDialer
+	if u.Scheme == "wss" && !verifySSL {
+		dialer.TLSClientConfig = &tls.Config{InsecureSkipVerify: true} // Disable SSL verification for wss
+	}
+
+	// Establish the WebSocket connection
+	conn, _, err := dialer.Dial(u.String(), nil)
+	if err != nil {
+		return nil, fmt.Errorf("failed to connect: %w", err)
+	}
+
+	client := &Client{
+		url:       serverURL,
+		conn:      conn,
+		pending:   make(map[int]chan json.RawMessage),
+		closeChan: make(chan struct{}),
+		jobs:      NewJobs(nil),
+	}
+
+	client.jobs = NewJobs(client)
+
+	go client.listen() // Start listening for WebSocket messages
+
+	return client, nil
+}
+
+// Close closes the WebSocket connection.
+func (c *Client) Close() error {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+
+	if c.isClosed {
+		return nil // Return if connection is already closed
+	}
+	c.isClosed = true
+	close(c.closeChan) // Signal that the connection is closed
+	err := c.conn.WriteMessage(websocket.CloseMessage, websocket.FormatCloseMessage(websocket.CloseNormalClosure, ""))
+	if err != nil {
+		return err
+	}
+	return c.conn.Close() // Close the actual WebSocket connection
+}
+
+// Call sends an RPC call to the server and waits for a response.
+func (c *Client) Call(method string, timeoutStr string, params interface{}) (json.RawMessage, error) {
+	timeout, err := time.ParseDuration(timeoutStr)
+	if err != nil || timeout < 0 {
+		return nil, errors.New("Invalid timeout was given: " + timeoutStr)
+	}
+
+	c.mu.Lock()
+	c.callID++ // Increment callID for each call
+	callID := c.callID
+	responseChan := make(chan json.RawMessage, 1) // Create channel to receive the response
+	c.pending[callID] = responseChan              // Store the callID and response channel
+	c.mu.Unlock()
+
+	defer func() {
+		c.mu.Lock()
+		delete(c.pending, callID) // Clean up the pending map after response is received
+		c.mu.Unlock()
+	}()
+
+	// Create the RPC request payload
+	request := map[string]interface{}{
+		"jsonrpc": "2.0",
+		"method":  method,
+		"id":      callID,
+		"params":  params,
+	}
+
+	// Send the request to the WebSocket server
+	if err := c.conn.WriteJSON(request); err != nil {
+		return nil, fmt.Errorf("failed to send call: %w", err)
+	}
+
+	// Wait for the response or timeout
+	select {
+	case res := <-responseChan:
+		return res, nil
+	case <-time.After(timeout):
+		return nil, errors.New("call timed out")
+	}
+}
+
+// listen listens for incoming WebSocket messages.
+func (c *Client) listen() {
+	for {
+		select {
+		case <-c.closeChan: // If the connection is closed, stop listening
+			return
+		default:
+			_, message, err := c.conn.ReadMessage() // Read message from WebSocket server
+			if err != nil {
+				if !websocket.IsCloseError(err, websocket.CloseNormalClosure, websocket.CloseGoingAway) {
+					// log.Printf("error reading message: %v", err) // Log any non-close error
+				}
+				c.Close()
+				return
+			}
+
+			var response map[string]interface{}
+			if err := json.Unmarshal(message, &response); err != nil {
+				continue // Ignore if message can't be parsed
+			}
+
+			// Handle collection update (e.g., job progress updates)
+			if method, ok := response["method"].(string); ok && method == "collection_update" {
+				params := response["params"].(map[string]interface{})
+				jobID := int64(params["id"].(float64))
+				fields := params["fields"].(map[string]interface{})
+
+				// Only handle jobs started by this client
+				if c.jobs.IsOwnedJob(jobID) {
+					progress := fields["progress"].(map[string]interface{})
+					description, _ := progress["description"].(string)
+					percent, _ := progress["percent"].(float64)
+					state, _ := fields["state"].(string)
+					result, _ := fields["result"].(string)
+					errors, _ := fields["error"].(string)
+
+					// Update the job state in the Jobs manager
+					c.jobs.UpdateJobState(jobID, state, percent, result, errors)
+
+					// Trigger the callback if it exists
+					if job, exists := c.jobs.jobs[jobID]; exists && job.Callback != nil {
+						job.Callback(percent, state, description)
+					}
+				}
+				continue
+			}
+
+			// Handle RPC responses by matching call ID
+			if id, ok := response["id"].(float64); ok {
+				callID := int(id)
+				c.mu.Lock()
+				if ch, exists := c.pending[callID]; exists {
+					ch <- message // Send message to pending call's channel
+				}
+				c.mu.Unlock()
+			}
+		}
+	}
+}
+
+// CallWithJob sends an RPC call that returns a job ID and tracks the long-running job.
+func (c *Client) CallWithJob(method string, params interface{}, callback func(progress float64, state string, desc string)) (*Job, error) {
+	// Call the API method
+	res, err := c.Call(method, "10s", params)
+	if err != nil {
+		return nil, err
+	}
+
+	// Parse the response and extract the job ID
+	var response map[string]interface{}
+	if err := json.Unmarshal(res, &response); err != nil {
+		return nil, fmt.Errorf("failed to parse response: %w", err)
+	}
+
+	if errorData, exists := response["error"]; exists {
+		return nil, fmt.Errorf("API error: %v", errorData)
+	}
+
+	// Extract job ID from the response
+	jobID, ok := response["result"].(float64)
+	if !ok {
+		return nil, fmt.Errorf("unexpected response format for job")
+	}
+
+	// Add the job to the Jobs manager
+	job := c.jobs.AddJob(int64(jobID), method)
+
+	// Mark this job as owned by this client
+	c.jobs.AddOwnedJob(int64(jobID))
+
+	// Set the callback function for job updates
+	job.Callback = callback
+
+	// Return the Job instance to allow tracking
+	return job, nil
+}
+
+// Ping sends a ping request to the server to check connectivity.
+func (c *Client) Ping() (string, error) {
+	res, err := c.Call("core.ping", "10s", []interface{}{}) // Empty array as params
+
+	if err != nil {
+		return "", err
+	}
+
+	// Parse the result from the response
+	var response map[string]interface{}
+	if err := json.Unmarshal(res, &response); err != nil {
+		return "", fmt.Errorf("failed to parse ping response: %w", err)
+	}
+
+	// Return the result (e.g., "pong") from the response
+	if result, exists := response["result"].(string); exists {
+		return result, nil
+	}
+
+	return "", errors.New("unexpected ping response format")
+}
+
+// Login attempts to log in using either username/password or an API key.
+func (c *Client) Login(username, password, apiKey string) error {
+	var params interface{}
+	var method string
+
+	if apiKey != "" {
+		// Use API key login
+		method = "auth.login_with_api_key"
+		params = []interface{}{apiKey}
+	} else if username != "" && password != "" {
+		// Use username and password login
+		method = "auth.login"
+		params = []interface{}{username, password}
+	} else {
+		return errors.New("either username/password or API key must be provided")
+	}
+
+	// Make the login call
+	res, err := c.Call(method, "10s", params)
+	if err != nil {
+		return fmt.Errorf("login failed: %w", err)
+	}
+
+	var response map[string]interface{}
+	if err := json.Unmarshal(res, &response); err != nil {
+		return fmt.Errorf("failed to parse login response: %w", err)
+	}
+
+	// Check if there's an error in the login response
+	if errorData, exists := response["error"]; exists {
+		return fmt.Errorf("login error: %v", errorData)
+	}
+
+	// Return success if login result is true
+	if result, exists := response["result"]; exists && result == true {
+		return nil
+	}
+
+	return errors.New("login failed, unexpected response")
+}


### PR DESCRIPTION
# truenas-admin

`truenas-admin` is a tool for administering datasets, snapshots and network shares that are hosted on a TrueNAS server.

## Install

`go build`

`go install`

## Configuration

TrueNAS hosts can be specified with a JSON configuration file.

```json
{
  "hosts":{
    "fangtooth":{
      "url":"wss://<servername>/api/current",
      "api_key":"api key goes here"
    },
    "other":{
      "url":"wss://<servername>/api/current",
      "api_key":"other api key",
    }
  }
}
```

The default path is `~/.truenas-admin/config.json`. It can be overridden with --config.

## Run

`truenas-admin --url <websocket server> --api-key <api key> <command>`

### Commands

- list
	- Print various datasets, snapshots and network shares
- dataset
	- Administer datasets/zvols and their associated shares
- snapshot
	- Administer snapshots
- share
	- Administer network shares

## Testing

`go test -v ./cmd`

## Middleware Patches

The following patches to middlewared are currently needed to support the Incus TrueNAS driver. After making the patches you will need to restart the middlewared service

Modify `zfs.dataset.rename` to support snapshots. The snapshot rename capability is required by Incus.

```diff
diff --git a/src/middlewared/middlewared/plugins/zfs_/dataset_actions.py b/src/middlewared/middlewared/plugins/zfs_/dataset_actions.py
index 5dc1780fd8..76c57b554c 100644
--- a/src/middlewared/middlewared/plugins/zfs_/dataset_actions.py
+++ b/src/middlewared/middlewared/plugins/zfs_/dataset_actions.py
@@ -83,10 +83,11 @@ class ZFSDatasetService(Service):
             Bool('recursive', default=False)
         )
     )
+
     def rename(self, name, options):
         try:
             with libzfs.ZFS() as zfs:
-                dataset = zfs.get_dataset(name)
+                dataset = zfs.get_object(name)
                 dataset.rename(options['new_name'], recursive=options['recursive'])
         except libzfs.ZFSException as e:
             self.logger.error('Failed to rename dataset', exc_info=True)
```

Increase `max_calls` to 100. Incus will exceed 20 calls in 60 seconds when creating a storage volume. This will be resolved with a connection-cache in future

```diff
diff --git a/src/middlewared/middlewared/utils/rate_limit/cache.py b/src/middlewared/middlewared/utils/rate_limit/cache.py
index b04ecc1ec1..40797b71a7 100644
--- a/src/middlewared/middlewared/utils/rate_limit/cache.py
+++ b/src/middlewared/middlewared/utils/rate_limit/cache.py
@@ -12,7 +12,7 @@ __all__ = ['RateLimitCache']
 @dataclass(frozen=True)
 class RateLimitConfig:
     """The maximum number of calls per unique consumer of the endpoint."""
-    max_calls: int = 20
+    max_calls: int = 100
     """The maximum time in seconds that a unique consumer may request an
     endpoint that is being rate limited."""
     max_period: int = 60

```
