### PR TITLE
send targets before testing iscsi

### DIFF
--- a/cmd/iscsi_util.go
+++ b/cmd/iscsi_util.go
@@ -465,7 +465,7 @@ func RunIscsiDeactivate(api core.Session, iqnTargetName string, ipPortalAddr str
 }
 
 func RunIscsiDiscover(api core.Session, portalAddr string) (string, error) {
-	return RunIscsiAdminTool(api, []string{"--mode", "discovery", "--type", "sendtargets", "--portal", portalAddr})
+	return RunIscsiAdminTool(api, []string{"--mode", "discoverydb", "--type", "sendtargets", "--discover", "--portal", portalAddr})
 }
 
 func TestIscsiDiscovery(api core.Session, portalAddr string) (string, error) {

--- a/cmd/iscsi_util.go
+++ b/cmd/iscsi_util.go
@@ -469,6 +469,7 @@ func RunIscsiDiscover(api core.Session, portalAddr string) (string, error) {
 }
 
 func TestIscsiDiscovery(api core.Session, portalAddr string) (string, error) {
+	RunIscsiDiscover(api, portalAddr)
 	return RunIscsiAdminTool(api, []string{"--mode", "discovery", "--portal", portalAddr})
 }
 

--- a/cmd/version.go
+++ b/cmd/version.go
@@ -33,8 +33,9 @@ import (
 0.6.1 `share iscsi locate --create/--delete`
 0.6.2 `snapshot rename` now calls zfs.snapshot.rename end-point
 0.7.0 Add service commands, iscsi test, --daemon-socket to override path to the daemon's socket, add --portal and --initiator flags
+0.7.1 Sends a sendtargets command before a plain discover. This seems to be required before verifying a portal
 */
-const VERSION = "0.7.0"
+const VERSION = "0.7.1"
 
 var versionCmd = &cobra.Command{
 	Use:   "version",


### PR DESCRIPTION
when testing an iscsi setup when nothing is discovered, you need to send targets first the issue then becomes that will error if there are no targets.

BUT I believe (although this is not 100% confirmed) that the discover without sendtargets will then succeed, and eventually, when there are targets, then it will work.