### PR TITLE
fix locating iscsi ipv6 targets

### DIFF
--- a/cmd/iscsi_util.go
+++ b/cmd/iscsi_util.go
@@ -288,12 +288,18 @@ func IterateActivatedIscsiShares(optIpPortalAddr string, callback func(root stri
 	if err != nil {
 		return
 	}
+
+	// Normalize IPv6 portal: remove brackets if present
+	optIpPortalAddr = strings.ReplaceAll(optIpPortalAddr, "[", "")
+	optIpPortalAddr = strings.ReplaceAll(optIpPortalAddr, "]", "")
+
 	for _, e := range diskEntries {
 		name := e.Name()
 		suffix := "-lun-0"
 		if !strings.HasSuffix(name, suffix) {
 			continue
 		}
+
 		pathPrefix := "ip-" + optIpPortalAddr
 		if !strings.HasPrefix(name, pathPrefix) {
 			continue


### PR DESCRIPTION
When locating an IPv6 target, the wrapping `[]` will not be present in the `/dev/disk/by-path` node... and should be stripped before attempting to locate the activated target.