### PR TITLE
Fix iscsi create for ipv6

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -207,5 +207,29 @@
           "args": ["--debug","--allow-insecure","--host","[fd9d:e7c2:3f61:3260::32]","--api-key","${env:TN_APIKEY}","--daemon-socket","${userHome}/tncdaemon2.sock","share","iscsi","locate","-t","incus","dozer/se-incus/tnPoolNOW/containers/d12-xfs"],
           "console": "integratedTerminal",
         },
+         {
+          // create share iscsi -t incus $TN_TEST_ZVOL
+          "name": "create iscsi share",
+          "type": "go",
+          "request": "launch",
+          "mode": "debug", 
+          "asRoot": true,
+
+          "program": "${workspaceFolder}",
+          "args": ["--debug","--allow-insecure","--host","[fd9d:e7c2:3f61:3260::32]","--api-key","${env:TN_APIKEY}","--daemon-socket","${userHome}/tncdaemon2.sock","share","iscsi","create","-t","incus","dozer/zvols-for-testing/zvol1"],
+          "console": "integratedTerminal",
+        },
+        {
+          // delete share iscsi -t incus $TN_TEST_ZVOL
+          "name": "delete iscsi share",
+          "type": "go",
+          "request": "launch",
+          "mode": "debug", 
+          "asRoot": true,
+
+          "program": "${workspaceFolder}",
+          "args": ["--debug","--allow-insecure","--host","[fd9d:e7c2:3f61:3260::32]","--api-key","${env:TN_APIKEY}","--daemon-socket","${userHome}/tncdaemon2.sock","share","iscsi","delete","-t","incus","dozer/zvols-for-testing/zvol1"],
+          "console": "integratedTerminal",
+        },
     ]
 }


### PR DESCRIPTION
When querying the API for the portal we need to strip the ip6 []s