### PR TITLE
0.7.6 Fix macOS/Windows compilation

### DIFF
--- a/build-install.sh
+++ b/build-install.sh
@@ -1,3 +1,2 @@
 #!/bin/sh
-./run_tests.sh && go install && truenas_incus_ctl version
-
+./run_tests.sh && go install && "$(go env GOPATH)/bin/truenas_incus_ctl" version

--- a/cmd/version.go
+++ b/cmd/version.go
@@ -38,8 +38,9 @@ import (
 0.7.3 IPv6 fixes
 0.7.4 Add :port support to --host
 0.7.5 Add `share iscsi refresh` to refresh the iscsi bus
+0.7.6 Fix macos/windows compilation issues
 */
-const VERSION = "0.7.5"
+const VERSION = "0.7.6"
 
 var versionCmd = &cobra.Command{
 	Use:   "version",

--- a/core/util.go
+++ b/core/util.go
@@ -14,7 +14,6 @@ import (
 	"slices"
 	"strconv"
 	"strings"
-	"syscall"
 )
 
 func DeleteSnakeKebab(dict map[string]string, key string) {
@@ -153,71 +152,6 @@ func GetKeysSorted[T any](dict map[string]T) []string {
 	return keys
 }
 
-func WaitForCreatedDeletedFiles(directory string, onFileEvent func(string, bool, bool)bool) error {
-	fdInotify, err := syscall.InotifyInit()
-	if err != nil {
-		return fmt.Errorf("syscall.InotifyInit: %v", err)
-	}
-	defer syscall.Close(fdInotify)
-
-	flagsInterested := uint32(syscall.IN_CREATE | syscall.IN_DELETE | syscall.IN_DELETE_SELF)
-	watchDesc, err := syscall.InotifyAddWatch(fdInotify, directory, flagsInterested)
-	if err != nil {
-		return fmt.Errorf("syscall.InotifyAddWatch: %v", err)
-	}
-	defer syscall.InotifyRmWatch(fdInotify, uint32(watchDesc)) // why is the type uint32 here?
-
-	var prevName string
-	wasCreate := false
-	wasDelete := false
-	buf := make([]byte, 4096)
-
-	for true {
-		if onFileEvent(prevName, wasCreate, wasDelete) {
-			break
-		}
-		prevName = ""
-		wasCreate = false
-
-		nRead := 0
-		nRead, err = syscall.Read(fdInotify, buf)
-		if err != nil {
-			return fmt.Errorf("syscall.Read fdInotify: %v (read %d bytes)", err, nRead)
-		}
-
-		nameLen := int(buf[12]) | (int(buf[13]) << 8) | (int(buf[14]) << 16) | (int(buf[15]) << 24)
-		if nameLen < 0 {
-			return fmt.Errorf("inotify event: invalid name length %d", nameLen)
-		}
-		if nameLen == 0 {
-			//fmt.Println("name was empty")
-			continue
-		}
-
-		name := string(buf[16:16+nameLen])
-		for bytePos, codePoint := range name {
-			if codePoint == 0 {
-				if bytePos == 0 {
-					name = ""
-					break
-				}
-				name = name[0:bytePos]
-				break
-			}
-		}
-
-		if len(name) == 0 {
-			continue
-		}
-
-		mask := uint32(buf[4]) | (uint32(buf[5]) << 8) | (uint32(buf[6]) << 16) | (uint32(buf[7]) << 24)
-		wasCreate = (mask & syscall.IN_CREATE) != 0
-		wasDelete = (mask & (syscall.IN_DELETE | syscall.IN_DELETE_SELF)) != 0
-		prevName = name
-	}
-
-	return nil
-}
 
 func MakeHashedString(input string, length int) string {
 	var h []byte

--- a/core/wait_inotify_linux.go
+++ b/core/wait_inotify_linux.go
@@ -1,0 +1,74 @@
+//go:build linux
+
+package core
+
+import (
+	"fmt"
+	"syscall"
+)
+
+func WaitForCreatedDeletedFiles(directory string, onFileEvent func(string, bool, bool) bool) error {
+	fdInotify, err := syscall.InotifyInit()
+	if err != nil {
+		return fmt.Errorf("syscall.InotifyInit: %v", err)
+	}
+	defer syscall.Close(fdInotify)
+
+	flagsInterested := uint32(syscall.IN_CREATE | syscall.IN_DELETE | syscall.IN_DELETE_SELF)
+	watchDesc, err := syscall.InotifyAddWatch(fdInotify, directory, flagsInterested)
+	if err != nil {
+		return fmt.Errorf("syscall.InotifyAddWatch: %v", err)
+	}
+	defer syscall.InotifyRmWatch(fdInotify, uint32(watchDesc)) // why is the type uint32 here?
+
+	var prevName string
+	wasCreate := false
+	wasDelete := false
+	buf := make([]byte, 4096)
+
+	for true {
+		if onFileEvent(prevName, wasCreate, wasDelete) {
+			break
+		}
+		prevName = ""
+		wasCreate = false
+
+		nRead := 0
+		nRead, err = syscall.Read(fdInotify, buf)
+		if err != nil {
+			return fmt.Errorf("syscall.Read fdInotify: %v (read %d bytes)", err, nRead)
+		}
+
+		nameLen := int(buf[12]) | (int(buf[13]) << 8) | (int(buf[14]) << 16) | (int(buf[15]) << 24)
+		if nameLen < 0 {
+			return fmt.Errorf("inotify event: invalid name length %d", nameLen)
+		}
+		if nameLen == 0 {
+			//fmt.Println("name was empty")
+			continue
+		}
+
+		name := string(buf[16 : 16+nameLen])
+		for bytePos, codePoint := range name {
+			if codePoint == 0 {
+				if bytePos == 0 {
+					name = ""
+					break
+				}
+				name = name[0:bytePos]
+				break
+			}
+		}
+
+		if len(name) == 0 {
+			continue
+		}
+
+		mask := uint32(buf[4]) | (uint32(buf[5]) << 8) | (uint32(buf[6]) << 16) | (uint32(buf[7]) << 24)
+		wasCreate = (mask & syscall.IN_CREATE) != 0
+		wasDelete = (mask & (syscall.IN_DELETE | syscall.IN_DELETE_SELF)) != 0
+		prevName = name
+	}
+
+	return nil
+}

--- a/core/wait_inotify_stub.go
+++ b/core/wait_inotify_stub.go
@@ -1,0 +1,9 @@
+//go:build !linux
+
+package core
+
+import "fmt"
+
+func WaitForCreatedDeletedFiles(directory string, onFileEvent func(string, bool, bool) bool) error {
+	return fmt.Errorf("inotify not supported on this platform")
+}


### PR DESCRIPTION
WaitForCreatedDeletedFiles was failing to compile on macos/windows, because it uses iNotify.

WaitForCreatedDeletedFiles was  split out to a linux specific file, and stubs used on other platforms.

The stub just retuns an "inotify not supported" error. Technically true, but could be replaced with other methods, the much bigger issue is that open-iscsi is not supported, and in order to implement the `share iscsi` functionality we would have to implement a lot of macos/windows specific code for dealing with what ever iscsi implementation was chosen.

This is possible, but it is not on the roadmap at all.

So, when using iscsi functionality you may see an error about "inotify not supported on this platform",  but in reality, you will probably seen `iscsiadm not found` instead.